### PR TITLE
OSPC-696:Code changes handle all user login and Tips to print configured Domain 

### DIFF
--- a/src/pages/auth/containers/Login/index.jsx
+++ b/src/pages/auth/containers/Login/index.jsx
@@ -212,8 +212,12 @@ export class Login extends Component {
       render: () => (
         <Input placeholder={t('<username> or <username>@<domain>')} />
       ),
-      extra: t(
-        'Tips: If no domain is provided, the configured default domain will be used.'
+
+      extra: (
+        <span>
+          Tips: If no domain is provided, the configured domain{' '}
+          {this.store.userDefaultDomain || 'Default'} will be used.
+        </span>
       ),
       rules: [{ required: true, validator: this.usernameDomainValidator }],
     };
@@ -376,17 +380,26 @@ export class Login extends Component {
   }
 
   getUsernameAndDomain = (values) => {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     const { usernameDomain } = values;
     const trimmedUsernameDomain = usernameDomain.trim();
-    const lastAtIndex = trimmedUsernameDomain.lastIndexOf('@');
-    const username =
-      lastAtIndex > 0
-        ? trimmedUsernameDomain.slice(0, lastAtIndex)
-        : trimmedUsernameDomain;
-    const domain =
-      lastAtIndex > 0
-        ? trimmedUsernameDomain.slice(lastAtIndex + 1)
-        : this.store.userDefaultDomain || 'Default';
+    let username;
+    let domain;
+
+    if (emailRegex.test(trimmedUsernameDomain)) {
+      username = trimmedUsernameDomain;
+      domain = this.store.userDefaultDomain || 'Default';
+    } else {
+      const lastAtIndex = trimmedUsernameDomain.lastIndexOf('@');
+      username =
+        lastAtIndex > 0
+          ? trimmedUsernameDomain.slice(0, lastAtIndex)
+          : trimmedUsernameDomain;
+      domain =
+        lastAtIndex > 0
+          ? trimmedUsernameDomain.slice(lastAtIndex + 1)
+          : this.store.userDefaultDomain || 'Default';
+    }
     return {
       username,
       domain,

--- a/src/pages/auth/containers/Login/index.jsx
+++ b/src/pages/auth/containers/Login/index.jsx
@@ -215,8 +215,8 @@ export class Login extends Component {
 
       extra: (
         <span>
-          Tips: If no domain is provided, the configured domain{' '}
-          {this.store.userDefaultDomain || 'Default'} will be used.
+          Tips: If no domain is specified, the configured domain{' '}
+          {`'${this.store.userDefaultDomain || 'Default'}'`} will be used.
         </span>
       ),
       rules: [{ required: true, validator: this.usernameDomainValidator }],


### PR DESCRIPTION
Code changes handle all user login and Tips to print configured Domain value on the console Page.
Verified the changes to allow different user can login using user name as follows ,
Type1:-
name@rackspcae.com@domain
Type2:-
username@domain

If the configured 'default_domain' parameter is configured on configbin.yaml, if that user belongs to that particular domain, then can login without mentioning the domain name in the user field:-
Type1 login can be - name@rackspace.com
Type2 login can be - username.

If the user is not belongs to the default_domain, Then during login need to enter their specific domain as well.


