### PR TITLE
OSPC-1119:Added new monitoring Url option while creating a Loadbalancer

### DIFF
--- a/src/pages/network/containers/LoadBalancers/Listener/Actions/EditHealthMonitor.jsx
+++ b/src/pages/network/containers/LoadBalancers/Listener/Actions/EditHealthMonitor.jsx
@@ -69,6 +69,7 @@ export class EditHealthMonitor extends ModalAction {
         max_retries: 3,
         enableHealthMonitor: false,
         admin_state_up: true,
+        url_path: '/',
       };
     }
     const {
@@ -78,6 +79,7 @@ export class EditHealthMonitor extends ModalAction {
       delay,
       timeout,
       max_retries,
+      url_path,
     } = healthMonitor;
     return {
       enableHealthMonitor: true,
@@ -87,6 +89,7 @@ export class EditHealthMonitor extends ModalAction {
       delay,
       timeout,
       max_retries,
+      url_path,
     };
   }
 
@@ -194,6 +197,27 @@ export class EditHealthMonitor extends ModalAction {
         tip: t('Defines the admin state of the health monitor.'),
         hidden: !enableHealthMonitor,
       },
+      {
+        name: 'url_path',
+        label: t('Monitoring URL'),
+        type: 'input',
+        rules: [
+          { required: false }, // Optional field
+          {
+            validator: (_, value) => {
+              if (value && !value.startsWith('/')) {
+                return Promise.reject(new Error(t('URL must start with /')));
+              }
+              return Promise.resolve();
+            },
+          },
+        ],
+        placeholder: t('e.g., /status.html or /healthcheck.html'),
+        extra: t(
+          'Optional; defaults to / if left empty. Recommended: use a status page like /status.html.'
+        ),
+        hidden: !enableHealthMonitor,
+      },
     ];
   }
 
@@ -201,12 +225,17 @@ export class EditHealthMonitor extends ModalAction {
     const { default_pool_id } = this.item;
     const { healthMonitor } = this.state;
     const { id } = healthMonitor || {};
-    const { enableHealthMonitor, type, ...others } = values;
+    const { enableHealthMonitor, type, url_path, ...others } = values;
+    const updatedUrlPath = url_path === '' || url_path == null ? '/' : url_path;
+
     if (id) {
       if (!enableHealthMonitor) {
         return globalHealthMonitorStore.delete({ id });
       }
-      return globalHealthMonitorStore.edit({ id }, others);
+      return globalHealthMonitorStore.edit(
+        { id },
+        { ...others, url_path: updatedUrlPath }
+      );
     }
     if (!enableHealthMonitor) {
       return Promise.resolve();
@@ -215,6 +244,7 @@ export class EditHealthMonitor extends ModalAction {
       type,
       ...others,
       pool_id: default_pool_id,
+      url_path: updatedUrlPath,
     };
     return globalHealthMonitorStore.create(data);
   };

--- a/src/pages/network/containers/LoadBalancers/Listener/Detail/BaseDetail.jsx
+++ b/src/pages/network/containers/LoadBalancers/Listener/Detail/BaseDetail.jsx
@@ -85,7 +85,8 @@ export class BaseDetail extends Base {
 
   get healthMonitor() {
     const healthMonitor = this.detailData.healthMonitor || {};
-    const { type, delay, timeout, max_retries, admin_state_up } = healthMonitor;
+    const { type, delay, timeout, max_retries, admin_state_up, url_path } =
+      healthMonitor;
     const options = [
       {
         label: t('Enable Health Monitor'),
@@ -114,6 +115,10 @@ export class BaseDetail extends Base {
           {
             label: t('Admin State Up'),
             content: admin_state_up ? t('On') : t('Off'),
+          },
+          {
+            label: t('Monitoiring URL'),
+            content: url_path || '/',
           },
         ]
       );

--- a/src/pages/network/containers/LoadBalancers/LoadBalancerInstance/actions/StepCreate/index.jsx
+++ b/src/pages/network/containers/LoadBalancers/LoadBalancerInstance/actions/StepCreate/index.jsx
@@ -95,6 +95,7 @@ export class StepCreate extends StepAction {
       pool_admin_state_up,
       monitor_admin_state_up,
       insert_headers,
+      health_url_path,
       ...rest
     } = values;
     const data = {
@@ -141,7 +142,10 @@ export class StepCreate extends StepAction {
     }
 
     const poolData = { admin_state_up: pool_admin_state_up };
-    const healthMonitorData = { admin_state_up: monitor_admin_state_up };
+    const healthMonitorData = {
+      admin_state_up: monitor_admin_state_up,
+      url_path: health_url_path,
+    };
     Object.keys(rest).forEach((i) => {
       if (i.indexOf('listener') === 0) {
         listenerData[i.replace('listener_', '')] = values[i];
@@ -153,7 +157,14 @@ export class StepCreate extends StepAction {
     });
 
     if (enableHealthMonitor) {
-      poolData.healthmonitor = healthMonitorData;
+      poolData.healthmonitor = {
+        ...healthMonitorData,
+        url_path:
+          healthMonitorData.url_path === '' ||
+          healthMonitorData.url_path == null
+            ? '/'
+            : healthMonitorData.url_path,
+      };
     }
     const {
       extMembers = [],

--- a/src/pages/network/containers/LoadBalancers/StepCreateComponents/HealthMonitorStep/index.jsx
+++ b/src/pages/network/containers/LoadBalancers/StepCreateComponents/HealthMonitorStep/index.jsx
@@ -42,6 +42,7 @@ export class HealthMonitorStep extends Base {
       health_max_retries: 3,
       health_type: '',
       monitor_admin_state_up: true,
+      health_url_path: '/',
     };
   }
 
@@ -122,6 +123,28 @@ export class HealthMonitorStep extends Base {
         label: t('Admin State Up'),
         type: 'switch',
         tip: t('Defines the admin state of the health monitor.'),
+        hidden: !enableHealthMonitor,
+      },
+      {
+        name: 'health_url_path',
+        label: t('Monitoring URL'),
+        type: 'input',
+        rules: [
+          { required: false },
+          {
+            validator: (_, value) => {
+              if (value && !value.startsWith('/')) {
+                return Promise.reject(new Error(t('URL must start with /')));
+              }
+              return Promise.resolve();
+            },
+          },
+        ],
+        initialValue: '/',
+        placeholder: t('e.g., /status.html or /healthcheck.html'),
+        extra: t(
+          'Optional; defaults to / if left empty. Recommended: use a status page like /status.html.'
+        ),
         hidden: !enableHealthMonitor,
       },
     ];


### PR DESCRIPTION
Added the new option to customize the Monitoiring URL in loadbalancer.
Atached the snapshot here which I have tested on DFW lab.

<img width="1897" height="929" alt="MonitorinUrlcustomize" src="https://github.com/user-attachments/assets/f5223af5-89b0-4638-b83a-ec2a055ca8a1" />
<img width="1879" height="932" alt="loadbalanceroperationsuccessful" src="https://github.com/user-attachments/assets/942ddb6c-6edc-4042-9621-b765fc58448f" />
<img width="1884" height="931" alt="Edithealthmonitor" src="https://github.com/user-attachments/assets/4562ab55-f2ff-400e-8056-152eaf55efc4" />
<img width="1890" height="931" alt="monitoringurwithvalue" src="https://github.com/user-attachments/assets/30c7a8c0-ff4a-4502-8361-2ce12814e484" />
<img width="2880" height="1800" alt="DBqueryHealthmonitor" src="https://github.com/user-attachments/assets/694d9816-b577-43f3-8f29-4f7ed295afe3" />


