### PR TITLE
OSPC-1440:Added the changes to display only enabled octavia flavors

### DIFF
--- a/src/stores/octavia/flavor.js
+++ b/src/stores/octavia/flavor.js
@@ -24,7 +24,8 @@ export class LoadBalancerFlavorStore extends Base {
       profileMap[profile.id] = profile;
     });
     // Merge needed fields into each flavor
-    const merged = flavors?.flavors.map((flavor) => {
+    const enabledFlavors = flavors?.flavors.filter((flavor) => flavor.enabled);
+    const merged = enabledFlavors?.map((flavor) => {
       const profile = profileMap[flavor.flavor_profile_id] || {};
       const flavorData = JSON.parse(profile?.flavor_data);
       return {


### PR DESCRIPTION
Added the code changes to display only enabled octavia flavors on the skyline UI.

Before the chages showing both enable and disable flavors,
<img width="1440" height="772" alt="showingallflavorsenable:disable" src="https://github.com/user-attachments/assets/1cf1b4cd-de4f-45f9-b3e3-acd7809819b0" />

And after chages, only showing showing enabled falvors can be seen in below image,
<img width="1426" height="779" alt="showingonlyenableflavor" src="https://github.com/user-attachments/assets/487e0168-1fea-4d09-b060-b2bdf61eae8c" />


