### PR TITLE
OSPC-1464:Added the changes to show instance name on member selection

### DIFF
--- a/src/components/FormItem/MemberAllocator/index.jsx
+++ b/src/components/FormItem/MemberAllocator/index.jsx
@@ -67,6 +67,10 @@ const MemberAllocator = ({ componentProps, formItemProps }) => {
               dataIndex: 'server_name',
             },
             {
+              title: t('Instance Name'), // New column for instance name
+              dataIndex: 'instance_name',
+            },
+            {
               title: t('IP'),
               dataIndex: 'fixed_ips',
               render: (fixed_ips, record) => {

--- a/src/stores/nova/instance-name.js
+++ b/src/stores/nova/instance-name.js
@@ -1,0 +1,85 @@
+// Copyright 2021 99cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { action, observable } from 'mobx';
+import client from 'client';
+
+class InstanceNameStore {
+  @observable
+  instanceDetails = new Map();
+
+  @action
+  async fetchInstanceNameByPortId(portId) {
+    if (!portId || typeof portId !== 'string' || portId.trim() === '') {
+      return '';
+    }
+
+    if (this.instanceDetails.has(portId)) {
+      return this.instanceDetails.get(portId);
+    }
+
+    let deviceId = '';
+    let instanceName = '';
+
+    try {
+      const portDetail = await client.neutron.ports.show(portId);
+      if (portDetail && typeof portDetail === 'object') {
+        deviceId =
+          (portDetail.port && portDetail.port.device_id) ||
+          portDetail.device_id ||
+          '';
+        const isComputeInstance =
+          portDetail.port?.device_owner?.startsWith('compute:') || false;
+        if (!deviceId || !isComputeInstance) {
+          return '';
+        }
+      }
+      if (!deviceId) {
+        return '';
+      }
+    } catch (portError) {
+      return '';
+    }
+
+    if (deviceId) {
+      try {
+        const server = await client.nova.servers.show(deviceId);
+        if (
+          server &&
+          typeof server === 'object' &&
+          server.server &&
+          typeof server.server === 'object' &&
+          'name' in server.server
+        ) {
+          instanceName = server.server.name || '';
+        }
+      } catch (serverError) {
+        try {
+          const serverList = await client.nova.servers.list();
+          const matchingServer = serverList.servers.find(
+            (s) => s.id === deviceId
+          );
+          if (matchingServer) {
+            instanceName = matchingServer.name || '';
+          }
+        } catch (listError) {}
+      }
+    }
+
+    this.instanceDetails.set(portId, instanceName);
+    return instanceName;
+  }
+}
+
+export default new InstanceNameStore();


### PR DESCRIPTION
Added the code changes to Display the Instance Name as new column while doing the member selection on Octavia Pannel.

Have attached the snapshot for both cases, 
1)During the Loadbalncer Creation showing the member details with instance name,
<img width="1422" height="774" alt="ShowingInstancename_Duringloadbalancercreation" src="https://github.com/user-attachments/assets/79d8900b-6242-48ee-8baa-83fd10649bc3" />

2)After the loadbalncer creation happened, under listener tab,Add Member section, instance name is visible now as well.
<img width="1429" height="780" alt="Showing_Instancename_Affter_loadbalancercreation_Addmemebersection" src="https://github.com/user-attachments/assets/e8f8b4f7-f0c7-4e41-885d-14bc2b968ed9" />

