### PR TITLE
OSPC-2091:Added UI changes for OSPC-2091 maintenance & Notifications feauture

### DIFF
--- a/src/client/skyline/index.js
+++ b/src/client/skyline/index.js
@@ -120,6 +120,21 @@ export class SkylineClient extends Base {
         ],
       },
       {
+        name: 'messageBanner',
+        key: 'message-banners',
+        responseKey: 'message_banner',
+        extendOperations: [
+          {
+            key: 'active',
+            isDetail: false,
+          },
+          {
+            key: 'public',
+            isDetail: false,
+          },
+        ],
+      },
+      {
         key: 'query',
       },
       {

--- a/src/layouts/Auth/index.jsx
+++ b/src/layouts/Auth/index.jsx
@@ -14,7 +14,11 @@
 
 import React, { Component } from 'react';
 import { inject, observer } from 'mobx-react';
+import { Tag } from 'antd';
+import { BellOutlined, ToolOutlined } from '@ant-design/icons';
 import renderRoutes from 'utils/RouterConfig';
+import globalMessageBannerStore from 'stores/skyline/message-banner';
+import { getMessageTypeLabel } from 'resources/skyline/message-banner';
 
 import loginFullImageWebp from 'asset/image/login-full.webp';
 import loginFullImagePng from 'asset/image/login-full.png';
@@ -27,7 +31,24 @@ export class AuthLayout extends Component {
   constructor(props) {
     super(props);
     this.routes = props.route.routes;
-    this.state = { backgroundLoaded: false };
+    this.state = { backgroundLoaded: false, currentSlide: 0 };
+  }
+
+  componentDidMount() {
+    globalMessageBannerStore.fetchPublic().catch(() => {});
+    this.autoSlideTimer = setInterval(() => {
+      if (this.paused) return;
+      const banners = globalMessageBannerStore.publicBanners || [];
+      if (banners.length > 1) {
+        this.setState((prevState) => ({
+          currentSlide: ((prevState.currentSlide || 0) + 1) % banners.length,
+        }));
+      }
+    }, 5000);
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.autoSlideTimer);
   }
 
   markBackgroundLoaded = () => {
@@ -39,6 +60,55 @@ export class AuthLayout extends Component {
   handleBackgroundImageRef = (img) => {
     if (img?.complete) this.markBackgroundLoaded();
   };
+
+  renderPublicBanners() {
+    const banners = globalMessageBannerStore.publicBanners || [];
+    if (!banners.length) {
+      return null;
+    }
+    const currentSlide = this.state.currentSlide || 0;
+    const banner = banners[currentSlide];
+    return (
+      <div className={styles.publicBanners}>
+        <div
+          className={styles.publicBannerCard}
+          onMouseEnter={() => {
+            this.paused = true;
+          }}
+          onMouseLeave={() => {
+            this.paused = false;
+          }}
+        >
+          <div className={styles.publicBannerContent}>
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 6,
+                marginBottom: 3,
+              }}
+            >
+              {banner.type === 'maintenance' ? (
+                <ToolOutlined style={{ fontSize: 12, color: '#666' }} />
+              ) : (
+                <BellOutlined style={{ fontSize: 12, color: '#666' }} />
+              )}
+              <Tag
+                color={banner.type === 'maintenance' ? 'blue' : 'orange'}
+                style={{ fontSize: 10, margin: 0 }}
+              >
+                {getMessageTypeLabel(banner.type)}
+              </Tag>
+            </div>
+            <div className={styles.publicBannerItemTitle}>
+              {banner.title || '-'}
+            </div>
+            <div className={styles.publicBannerMessage}>{banner.message}</div>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   render() {
     const { backgroundLoaded } = this.state;
@@ -118,6 +188,7 @@ export class AuthLayout extends Component {
             </p>
           </div>
         </div>
+        {this.renderPublicBanners()}
       </div>
     );
   }

--- a/src/layouts/Auth/index.less
+++ b/src/layouts/Auth/index.less
@@ -350,3 +350,132 @@
     }
   }
 }
+
+// Public banner notifications on login page
+.publicBanners {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  z-index: 100;
+}
+
+.publicBannerCard {
+  position: relative;
+  width: 550px;
+  max-width: calc(100vw - 32px);
+  height: 100px;
+  padding: 10px 14px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 95%);
+  border-radius: 8px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 15%);
+}
+
+.publicBannerTitle {
+  margin-bottom: 8px;
+  padding-bottom: 6px;
+  color: #333;
+  font-weight: 600;
+  font-size: 13px;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.publicBannerBody {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  height: 100%;
+}
+
+.publicBannerContent {
+  flex: 1;
+  overflow: hidden;
+}
+
+.publicBannerNavTop {
+  position: absolute;
+  top: 8px;
+  right: 10px;
+  display: flex;
+  gap: 4px;
+}
+
+.publicBannerSlider {
+  min-height: 100px;
+}
+
+.publicBannerItemTitle {
+  margin-bottom: 4px;
+  color: #333;
+  font-weight: 600;
+  font-size: 12px;
+}
+
+.publicBannerMessage {
+  max-height: 30px;
+  overflow-y: auto;
+  color: #555;
+  font-size: 12px;
+  line-height: 18px;
+  white-space: pre-line;
+  word-break: break-word;
+
+  // Thin scrollbar
+  &::-webkit-scrollbar {
+    width: 2px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: rgba(0, 0, 0, 20%);
+    border-radius: 2px;
+
+    &:hover {
+      background: rgba(0, 0, 0, 35%);
+    }
+  }
+
+  scrollbar-width: thin;
+  scrollbar-color: rgba(0, 0, 0, 20%) transparent;
+}
+
+.publicBannerMeta {
+  margin-top: 4px;
+  color: #888;
+  font-size: 11px;
+}
+
+.publicBannerNav {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  justify-content: center;
+  margin-top: 8px;
+  padding-top: 6px;
+  border-top: 1px solid #f0f0f0;
+}
+
+.publicBannerDots {
+  color: #999;
+  font-size: 11px;
+}
+
+.publicBannerItem {
+  display: flex;
+  gap: 6px;
+  align-items: flex-start;
+  margin-bottom: 8px;
+}
+
+.publicBannerText {
+  flex: 1;
+  overflow: hidden;
+  color: #555;
+  font-size: 12px;
+  line-height: 18px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}

--- a/src/layouts/admin-menu.jsx
+++ b/src/layouts/admin-menu.jsx
@@ -23,6 +23,7 @@ import {
   HomeOutlined,
   SwitcherOutlined,
   ContainerOutlined,
+  BellOutlined,
   DatabaseFilled,
   DeploymentUnitOutlined,
   BookOutlined,
@@ -956,6 +957,20 @@ const renderMenu = (t) => {
               routePath: '/configuration-admin/metadata/detail/:id',
             },
           ],
+        },
+      ],
+    },
+    {
+      path: '/maintenance-notifications-admin',
+      name: t('System Maintenance'),
+      key: 'maintenanceNotificationsAdmin',
+      icon: <BellOutlined />,
+      children: [
+        {
+          path: '/maintenance-notifications-admin/banners',
+          name: t('System Maintenance'),
+          key: 'maintNotifBannersAdmin',
+          level: 1,
         },
       ],
     },

--- a/src/pages/auth/containers/Login/index.jsx
+++ b/src/pages/auth/containers/Login/index.jsx
@@ -20,6 +20,7 @@ import { InfoCircleFilled } from '@ant-design/icons';
 import SimpleForm from 'components/SimpleForm';
 import SelectLang from 'components/SelectLang';
 import globalSkylineStore from 'stores/skyline/skyline';
+import globalMessageBannerStore from 'stores/skyline/message-banner';
 import i18n from 'core/i18n';
 import { isEmpty } from 'lodash';
 import logo from 'asset/image/logo.png';
@@ -41,6 +42,7 @@ export class Login extends Component {
     this.getRegions();
     this.getSSO();
     this.getUserDefaultDomain();
+    this.fetchPublicBanners();
   }
 
   async getRegions() {
@@ -498,6 +500,14 @@ export class Login extends Component {
     }
   };
 
+  async fetchPublicBanners() {
+    try {
+      await globalMessageBannerStore.fetchPublic();
+    } catch (e) {
+      // no-op
+    }
+  }
+
   init() {
     this.store = globalSkylineStore;
     this.formRef = React.createRef();
@@ -521,87 +531,90 @@ export class Login extends Component {
     }`;
 
     return (
-      <div
-        className={styles.loginContainer}
-        role="article"
-        aria-label="Login form container"
-      >
-        {/* Fixed header section - Logo only */}
+      <>
         <div
-          className={styles.headerSection}
-          role="banner"
-          aria-label="Application header"
+          className={styles.loginContainer}
+          role="article"
+          aria-label="Login form container"
         >
-          <img
-            alt="Application logo"
-            className={styles.headerLogo}
-            src={logo}
-          />
-        </div>
-
-        {/* Language selector */}
-        <div
-          className={styles.langSelector}
-          role="region"
-          aria-label="Language selection"
-        >
-          <SelectLang />
-        </div>
-
-        {/* Scrollable content area */}
-        {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
-        <div
-          className={scrollableClass}
-          onKeyDown={(e) => e.key === 'Enter' && this.handleSubmit()}
-        >
-          <div role="main" aria-label="Login form content">
-            <h1
-              className={styles.welcomeMessage}
-              id="login-title"
-              aria-level="1"
-            >
-              {this.productName}
-            </h1>
-
-            <SimpleForm
-              formItems={this.formItemsWithoutSubmit}
-              name="normal_login"
-              className={styles.loginForm}
-              initialValues={this.defaultValue}
-              onFinish={this.onFinish}
-              formref={this.formRef}
-              size="large"
-              aria-labelledby="login-title"
-              aria-describedby="login-description"
+          {/* Fixed header section - Logo only */}
+          <div
+            className={styles.headerSection}
+            role="banner"
+            aria-label="Application header"
+          >
+            <img
+              alt="Application logo"
+              className={styles.headerLogo}
+              src={logo}
             />
+          </div>
 
-            {this.renderExtra()}
+          {/* Language selector */}
+          <div
+            className={styles.langSelector}
+            role="region"
+            aria-label="Language selection"
+          >
+            <SelectLang />
+          </div>
+
+          {/* Scrollable content area */}
+          {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
+          <div
+            className={scrollableClass}
+            onKeyDown={(e) => e.key === 'Enter' && this.handleSubmit()}
+          >
+            <div role="main" aria-label="Login form content">
+              <h1
+                className={styles.welcomeMessage}
+                id="login-title"
+                aria-level="1"
+              >
+                {this.productName}
+              </h1>
+
+              <SimpleForm
+                formItems={this.formItemsWithoutSubmit}
+                name="normal_login"
+                className={styles.loginForm}
+                initialValues={this.defaultValue}
+                onFinish={this.onFinish}
+                formref={this.formRef}
+                size="large"
+                aria-labelledby="login-title"
+                aria-describedby="login-description"
+              />
+
+              {/* renderExtra moved outside */}
+            </div>
+          </div>
+
+          {/* Fixed bottom section */}
+          <div
+            className={styles.bottomSection}
+            role="region"
+            aria-label="Form submission section"
+          >
+            <Button
+              loading={loading}
+              type="primary"
+              htmlType="submit"
+              className={styles.loginButton}
+              size="large"
+              block
+              onClick={this.handleSubmit}
+              aria-label={
+                loading ? window.t('Logging in...') : window.t('Log in')
+              }
+              aria-describedby="login-title"
+            >
+              {window.t('Log in')}
+            </Button>
           </div>
         </div>
-
-        {/* Fixed bottom section */}
-        <div
-          className={styles.bottomSection}
-          role="region"
-          aria-label="Form submission section"
-        >
-          <Button
-            loading={loading}
-            type="primary"
-            htmlType="submit"
-            className={styles.loginButton}
-            size="large"
-            block
-            onClick={this.handleSubmit}
-            aria-label={
-              loading ? window.t('Logging in...') : window.t('Log in')
-            }
-            aria-describedby="login-title"
-          >
-            {window.t('Log in')}
-          </Button>
-        </div>
-      </div>
+        {this.renderExtra()}
+      </>
     );
   }
 }

--- a/src/pages/auth/containers/Login/index.less
+++ b/src/pages/auth/containers/Login/index.less
@@ -579,3 +579,43 @@
 .signupLink {
   will-change: transform;
 }
+
+// Login page banner notification card
+.loginBanners {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  z-index: 1000;
+}
+
+.loginBannerCard {
+  width: 280px;
+  padding: 12px;
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 8px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.15);
+}
+
+.loginBannerTitle {
+  margin-bottom: 8px;
+  color: #333;
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.loginBannerItem {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.loginBannerText {
+  flex: 1;
+  overflow: hidden;
+  color: #555;
+  font-size: 12px;
+  line-height: 18px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}

--- a/src/pages/base/containers/Overview/components/MessageBannerPanel.jsx
+++ b/src/pages/base/containers/Overview/components/MessageBannerPanel.jsx
@@ -1,0 +1,201 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React, { Component } from 'react';
+import { observer } from 'mobx-react';
+import { Card, Spin, Tag } from 'antd';
+import {
+  ToolOutlined,
+  BellOutlined,
+  LeftOutlined,
+  RightOutlined,
+} from '@ant-design/icons';
+import globalMessageBannerStore from 'stores/skyline/message-banner';
+import {
+  formatUtcTime,
+  getMessageTypeLabel,
+  parseUtcTime,
+} from 'resources/skyline/message-banner';
+import styles from '../style.less';
+
+export class MessageBannerPanel extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      now: Date.now(),
+      currentSlide: 0,
+    };
+  }
+
+  componentDidMount() {
+    this.fetchActive();
+    this.expireTimer = setInterval(this.updateNow, 60000);
+    this.refreshTimer = setInterval(this.fetchActive, 300000);
+    this.autoSlideTimer = setInterval(this.autoSlide, 5000);
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.expireTimer);
+    clearInterval(this.refreshTimer);
+    clearInterval(this.autoSlideTimer);
+  }
+
+  get store() {
+    return globalMessageBannerStore;
+  }
+
+  get activeBanners() {
+    const { now } = this.state;
+    return this.store.activeBanners.filter((banner) => {
+      const expiresAt = parseUtcTime(banner.expires_at);
+      return expiresAt && expiresAt.valueOf() > now;
+    });
+  }
+
+  fetchActive = () => {
+    globalMessageBannerStore.fetchActive().catch(() => {});
+  };
+
+  updateNow = () => {
+    this.setState({
+      now: Date.now(),
+    });
+  };
+
+  autoSlide = () => {
+    if (this.paused) {
+      return;
+    }
+    this.advanceSlide(1);
+  };
+
+  advanceSlide = (step) => {
+    const total = this.activeBanners.length;
+    if (total <= 1) {
+      return;
+    }
+    this.setState((prevState) => ({
+      currentSlide: ((prevState.currentSlide || 0) + step + total) % total,
+    }));
+  };
+
+  renderMeta(label, value) {
+    if (!value) {
+      return null;
+    }
+    return (
+      <div className={styles['banner-meta-item']}>
+        <span className={styles['banner-meta-label']}>{label}</span>
+        <span>{value}</span>
+      </div>
+    );
+  }
+
+  renderIcon(type) {
+    return type === 'maintenance' ? <ToolOutlined /> : <BellOutlined />;
+  }
+
+  renderBanner = (banner) => {
+    const {
+      id,
+      type,
+      title,
+      message,
+      impacted_service,
+      start_at,
+      expires_at,
+      region,
+    } = banner;
+    const isMaintenance = type === 'maintenance';
+    const color = isMaintenance ? 'blue' : 'orange';
+    const slideClass = isMaintenance
+      ? `${styles['banner-slide']} ${styles['banner-slide-maintenance']}`
+      : `${styles['banner-slide']} ${styles['banner-slide-notification']}`;
+    return (
+      <div className={slideClass} key={id}>
+        <div className={styles['banner-header']}>
+          <Tag color={color} className={styles['banner-type']}>
+            {this.renderIcon(type)}
+            <span>{getMessageTypeLabel(type)}</span>
+          </Tag>
+          <div className={styles['banner-title']}>{title || '-'}</div>
+        </div>
+        <div className={styles['banner-message']}>{message}</div>
+        <div className={styles['banner-meta']}>
+          {this.renderMeta(t('Impacted Service'), impacted_service)}
+          {this.renderMeta(t('Region'), region || t('All Regions'))}
+          {this.renderMeta(
+            t('Start Time (UTC)'),
+            start_at ? formatUtcTime(start_at) : null
+          )}
+          {this.renderMeta(t('End Time (UTC)'), formatUtcTime(expires_at))}
+        </div>
+      </div>
+    );
+  };
+
+  renderContent() {
+    const { activeBanners } = this;
+    if (!activeBanners.length) {
+      return null;
+    }
+    if (activeBanners.length === 1) {
+      return this.renderBanner(activeBanners[0]);
+    }
+    const total = activeBanners.length;
+    const currentSlide = (this.state.currentSlide || 0) % total;
+    return (
+      <div
+        className={styles['banner-carousel']}
+        onMouseEnter={() => {
+          this.paused = true;
+        }}
+        onMouseLeave={() => {
+          this.paused = false;
+        }}
+      >
+        {this.renderBanner(activeBanners[currentSlide])}
+        <button
+          aria-label={t('Previous message banner')}
+          className={`${styles['banner-nav-btn']} ${styles['banner-nav-left']}`}
+          onClick={() => this.advanceSlide(-1)}
+          type="button"
+        >
+          <LeftOutlined />
+        </button>
+        <button
+          aria-label={t('Next message banner')}
+          className={`${styles['banner-nav-btn']} ${styles['banner-nav-right']}`}
+          onClick={() => this.advanceSlide(1)}
+          type="button"
+        >
+          <RightOutlined />
+        </button>
+      </div>
+    );
+  }
+
+  render() {
+    const { activeBanners } = this;
+    const { isActiveLoading } = this.store;
+    if (!activeBanners.length && !isActiveLoading) {
+      return null;
+    }
+    return (
+      <Card className={styles['message-banner']} bordered={false}>
+        <Spin spinning={isActiveLoading}>{this.renderContent()}</Spin>
+      </Card>
+    );
+  }
+}
+
+export default observer(MessageBannerPanel);

--- a/src/pages/base/containers/Overview/index.jsx
+++ b/src/pages/base/containers/Overview/index.jsx
@@ -27,6 +27,7 @@ import styles from './style.less';
 import QuotaOverview from './components/QuotaOverview';
 import ProjectInfo from './components/ProjectInfo';
 import QuickStartNetwork from './components/QuickStartNetwork';
+import MessageBannerPanel from './components/MessageBannerPanel';
 
 const actions = [
   {
@@ -156,7 +157,7 @@ export class Overview extends Component {
   }
 
   renderExtra() {
-    return null;
+    return <MessageBannerPanel />;
   }
 
   render() {

--- a/src/pages/base/containers/Overview/style.less
+++ b/src/pages/base/containers/Overview/style.less
@@ -210,6 +210,133 @@
   }
 }
 
+.message-banner {
+  margin-top: 16px;
+
+  :global {
+    .ant-card-body {
+      padding: 16px;
+    }
+
+    .slick-dots-bottom {
+      bottom: 0;
+    }
+
+    .slick-arrow {
+      z-index: 1;
+      display: flex !important;
+      align-items: center;
+      justify-content: center;
+      width: 28px;
+      height: 28px;
+      color: #374151;
+      background: #fff;
+      border: 1px solid #d1d5db;
+      border-radius: 50%;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 10%);
+      opacity: 0.9;
+      transition: all 0.2s;
+    }
+
+    .slick-arrow::before {
+      color: #374151;
+      font-size: 12px;
+    }
+
+    .slick-arrow:hover {
+      color: #000;
+      background: #f3f4f6;
+      border-color: #000;
+      opacity: 1;
+    }
+
+    .slick-arrow:hover::before {
+      color: #000;
+    }
+
+    .slick-prev {
+      left: 12px;
+    }
+
+    .slick-next {
+      right: 12px;
+    }
+  }
+}
+
+.banner-slide {
+  min-height: 184px;
+  padding: 16px;
+  padding-right: 28px;
+  padding-bottom: 24px;
+  padding-left: 12px;
+  border-radius: 6px;
+}
+
+.banner-slide-maintenance {
+  background: #eff6ff;
+  border: 1px solid #bfdbfe;
+}
+
+.banner-slide-notification {
+  background: #fff7ed;
+  border: 1px solid #fed7aa;
+}
+
+.banner-header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: flex-start;
+  margin-bottom: 12px;
+}
+
+.banner-type {
+  display: inline-flex;
+  flex-shrink: 0;
+  gap: 4px;
+  align-items: center;
+  margin-top: 2px;
+  border: none !important;
+}
+
+.banner-title {
+  color: #252525;
+  font-weight: 600;
+  line-height: 22px;
+  word-break: break-word;
+}
+
+.banner-message {
+  max-height: 180px;
+  overflow: auto;
+  color: #4a4a4a;
+  font-size: 13px;
+  line-height: 20px;
+  white-space: pre-line;
+  word-break: break-word;
+}
+
+.banner-meta {
+  margin-top: 12px;
+  color: #6b7280;
+  font-size: 12px;
+}
+
+.banner-meta-item {
+  display: flex;
+  gap: 8px;
+  margin-top: 4px;
+  white-space: nowrap;
+}
+
+.banner-meta-label {
+  flex-shrink: 0;
+  min-width: 100px;
+  color: #4b5563;
+  font-weight: 500;
+}
+
 @media (max-width: 1366px) {
   .container {
     padding: 20px;
@@ -283,4 +410,86 @@
       }
     }
   }
+}
+
+.banner-carousel {
+  position: relative;
+}
+
+.banner-arrow {
+  position: absolute;
+  top: 50%;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  color: #374151;
+  font-weight: bold;
+  font-size: 20px;
+  line-height: 1;
+  background: #fff;
+  border: 1px solid #d1d5db;
+  border-radius: 50%;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 10%);
+  transform: translateY(-50%);
+  cursor: pointer;
+  transition: all 0.2s;
+  user-select: none;
+
+  &:hover {
+    color: #000;
+    background: #f3f4f6;
+    border-color: #000;
+  }
+}
+
+.banner-arrow-left {
+  left: 0;
+}
+
+.banner-arrow-right {
+  right: 0;
+}
+
+.banner-dots {
+  margin-top: 8px;
+  color: #999;
+  font-size: 12px;
+  text-align: center;
+}
+
+.banner-nav-btn {
+  position: absolute;
+  top: 50%;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  color: #6b7280;
+  font-size: 9px;
+  line-height: 1;
+  background: rgba(0, 0, 0, 4%);
+  border: none;
+  border-radius: 50%;
+  transform: translateY(-50%);
+  cursor: pointer;
+  transition: color 0.2s, background 0.2s;
+
+  &:hover {
+    color: #000;
+    background: rgba(0, 0, 0, 10%);
+  }
+}
+
+.banner-nav-left {
+  left: 0;
+}
+
+.banner-nav-right {
+  right: 0;
 }

--- a/src/pages/basic/routes/index.js
+++ b/src/pages/basic/routes/index.js
@@ -29,6 +29,11 @@ const Network = lazy(() =>
 const Identity = lazy(() =>
   import(/* webpackChunkName: "identity" */ 'pages/identity/App')
 );
+const SystemMaintenance = lazy(() =>
+  import(
+    /* webpackChunkName: "maintenance-notifications" */ 'pages/maintenance-notifications/App'
+  )
+);
 const Configs = lazy(() =>
   import(/* webpackChunkName: "configuration" */ 'pages/configuration/App')
 );
@@ -89,6 +94,10 @@ export default [
       {
         path: `/configuration-admin`,
         component: Configs,
+      },
+      {
+        path: `/maintenance-notifications-admin`,
+        component: SystemMaintenance,
       },
       {
         path: `/management`,

--- a/src/pages/maintenance-notifications/App.jsx
+++ b/src/pages/maintenance-notifications/App.jsx
@@ -1,0 +1,19 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import renderRoutes from 'utils/RouterConfig';
+
+import routes from './routes';
+
+const App = (props) => renderRoutes(routes, props);
+
+export default App;

--- a/src/pages/maintenance-notifications/containers/MessageBanner/BannerList.jsx
+++ b/src/pages/maintenance-notifications/containers/MessageBanner/BannerList.jsx
@@ -1,0 +1,167 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react';
+import { observer, inject } from 'mobx-react';
+import { Tag } from 'antd';
+import Base from 'containers/List';
+import globalMessageBannerStore from 'stores/skyline/message-banner';
+import { onlyAdminCanReadPolicy } from 'resources/skyline/policy';
+import {
+  enabledOptions,
+  formatUtcTime,
+  getMessageSourceLabel,
+  getMessageTypeLabel,
+  sourceOptions,
+} from 'resources/skyline/message-banner';
+import { maintenanceActionConfigs, notificationActionConfigs } from './actions';
+import styles from './index.less';
+
+export class BannerList extends Base {
+  init() {
+    this.store = globalMessageBannerStore;
+  }
+
+  get policy() {
+    return onlyAdminCanReadPolicy;
+  }
+
+  get name() {
+    return t('Message Banner');
+  }
+
+  get rowKey() {
+    return 'id';
+  }
+
+  get hideDownload() {
+    return true;
+  }
+
+  get actionConfigs() {
+    const { tab } = this.props;
+    return tab === 'notification'
+      ? notificationActionConfigs
+      : maintenanceActionConfigs;
+  }
+
+  renderType = (type) => {
+    const color = type === 'maintenance' ? 'orange' : 'blue';
+    return <Tag color={color}>{getMessageTypeLabel(type)}</Tag>;
+  };
+
+  renderSource = (source) => {
+    const color = source === 'manual' ? 'green' : 'purple';
+    return <Tag color={color}>{getMessageSourceLabel(source)}</Tag>;
+  };
+
+  renderEnabled = (enabled, record) => {
+    const now = new Date();
+    const expiresAt = new Date(record.expires_at);
+    const isExpired = expiresAt <= now;
+    const isDisabledByAdmin = !enabled && !isExpired;
+
+    if (isDisabledByAdmin) {
+      return (
+        <span>
+          <Tag color="red">{t('Inactive')}</Tag>
+          <Tag color="orange">{t('Disabled')}</Tag>
+        </span>
+      );
+    }
+    if (isExpired || !enabled) {
+      return <Tag color="default">{t('Inactive')}</Tag>;
+    }
+    return <Tag color="green">{t('Active')}</Tag>;
+  };
+
+  renderMessage = (message) => (
+    <div className={styles.message}>{message || '-'}</div>
+  );
+
+  getColumns() {
+    const { tab } = this.props;
+    const isMaintenance = tab !== 'notification';
+    const columns = [
+      {
+        title: t('Title'),
+        dataIndex: 'title',
+        width: 200,
+        render: (value) => value || '-',
+      },
+      {
+        title: t('Message'),
+        dataIndex: 'message',
+        width: 400,
+        render: this.renderMessage,
+      },
+    ];
+    if (isMaintenance) {
+      columns.push({
+        title: t('Start_Time'),
+        dataIndex: 'start_at',
+        width: 160,
+        render: formatUtcTime,
+      });
+    }
+    columns.push(
+      {
+        title: t('End_Time'),
+        dataIndex: 'expires_at',
+        width: 160,
+        render: formatUtcTime,
+      },
+      {
+        title: t('Source'),
+        dataIndex: 'source',
+        width: 90,
+        render: this.renderSource,
+      },
+      {
+        title: t('Status'),
+        dataIndex: 'enabled',
+        width: 90,
+        render: this.renderEnabled,
+      }
+    );
+    return columns;
+  }
+
+  get searchFilters() {
+    return [
+      {
+        label: t('Title'),
+        name: 'title',
+      },
+      {
+        label: t('Message'),
+        name: 'message',
+      },
+      {
+        label: t('Region'),
+        name: 'region',
+      },
+      {
+        label: t('Source'),
+        name: 'source',
+        options: sourceOptions,
+      },
+      {
+        label: t('Status'),
+        name: 'enabled',
+        options: enabledOptions,
+      },
+    ];
+  }
+}
+
+export default inject('rootStore')(observer(BannerList));

--- a/src/pages/maintenance-notifications/containers/MessageBanner/actions/CreateMaintenance.jsx
+++ b/src/pages/maintenance-notifications/containers/MessageBanner/actions/CreateMaintenance.jsx
@@ -1,0 +1,108 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { inject, observer } from 'mobx-react';
+import { ModalAction } from 'containers/Action';
+import globalMessageBannerStore from 'stores/skyline/message-banner';
+import { onlyAdminCanChangePolicy } from 'resources/skyline/policy';
+import {
+  getMessageBannerPayload,
+  getMessageTypeLabel,
+  utcInputPlaceholder,
+  utcTimeValidator,
+} from 'resources/skyline/message-banner';
+
+export class Create extends ModalAction {
+  static id = 'create';
+
+  static title = t('Create Maintenance');
+
+  static policy = onlyAdminCanChangePolicy;
+
+  static allowed = () => Promise.resolve(true);
+
+  init() {
+    this.store = globalMessageBannerStore;
+  }
+
+  get messageType() {
+    return this.containerProps.tab || 'maintenance';
+  }
+
+  get name() {
+    return t('Create {type}', {
+      type: getMessageTypeLabel(this.messageType),
+    });
+  }
+
+  get defaultValue() {
+    const { region } = this.currentUser || {};
+    return {
+      enabled: true,
+      region,
+    };
+  }
+
+  getModalSize() {
+    return 'large';
+  }
+
+  get formItems() {
+    const isMaintenance = this.messageType === 'maintenance';
+    return [
+      {
+        name: 'title',
+        label: t('Title'),
+        type: 'input',
+        required: true,
+      },
+      {
+        name: 'impacted_service',
+        label: t('Impacted Service'),
+        type: 'input',
+        required: false,
+        display: isMaintenance,
+      },
+      {
+        name: 'start_at',
+        label: t('Start_Time (UTC)'),
+        type: 'date-picker',
+        showTime: true,
+        placeholder: utcInputPlaceholder,
+        required: isMaintenance,
+        validator: utcTimeValidator,
+        display: isMaintenance,
+      },
+      {
+        name: 'expires_at',
+        label: t('End_Time (UTC)'),
+        type: 'date-picker',
+        showTime: true,
+        placeholder: utcInputPlaceholder,
+        required: true,
+        validator: utcTimeValidator,
+      },
+      {
+        name: 'message',
+        label: t('Message'),
+        type: 'textarea',
+        required: true,
+        rows: 6,
+      },
+    ];
+  }
+
+  onSubmit = (values) =>
+    this.store.create(getMessageBannerPayload(values, this.messageType));
+}
+
+export default inject('rootStore')(observer(Create));

--- a/src/pages/maintenance-notifications/containers/MessageBanner/actions/CreateNotification.jsx
+++ b/src/pages/maintenance-notifications/containers/MessageBanner/actions/CreateNotification.jsx
@@ -1,0 +1,22 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { inject, observer } from 'mobx-react';
+import { Create } from './CreateMaintenance';
+
+export class CreateNotification extends Create {
+  static id = 'create-notification';
+
+  static title = t('Create Notification');
+}
+
+export default inject('rootStore')(observer(CreateNotification));

--- a/src/pages/maintenance-notifications/containers/MessageBanner/actions/Delete.jsx
+++ b/src/pages/maintenance-notifications/containers/MessageBanner/actions/Delete.jsx
@@ -1,0 +1,45 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { ConfirmAction } from 'containers/Action';
+import globalMessageBannerStore from 'stores/skyline/message-banner';
+import { onlyAdminCanChangePolicy } from 'resources/skyline/policy';
+
+export default class DeleteAction extends ConfirmAction {
+  get id() {
+    return 'delete';
+  }
+
+  get title() {
+    return t('Delete Message Banner');
+  }
+
+  get isDanger() {
+    return true;
+  }
+
+  get buttonText() {
+    return t('Delete');
+  }
+
+  get actionName() {
+    return t('Delete message banner');
+  }
+
+  policy = onlyAdminCanChangePolicy;
+
+  allowed = (item) => Promise.resolve(item.source === 'manual');
+
+  getItemName = (data) => data.title || `- (${data.id})`;
+
+  onSubmit = (data) => globalMessageBannerStore.delete({ id: data.id });
+}

--- a/src/pages/maintenance-notifications/containers/MessageBanner/actions/Edit.jsx
+++ b/src/pages/maintenance-notifications/containers/MessageBanner/actions/Edit.jsx
@@ -1,0 +1,129 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { inject, observer } from 'mobx-react';
+import { ModalAction } from 'containers/Action';
+import globalMessageBannerStore from 'stores/skyline/message-banner';
+import { onlyAdminCanChangePolicy } from 'resources/skyline/policy';
+import {
+  formatUtcInput,
+  getMessageBannerPayload,
+  getMessageTypeLabel,
+  utcInputPlaceholder,
+  utcTimeValidator,
+} from 'resources/skyline/message-banner';
+
+export class Edit extends ModalAction {
+  static id = 'edit';
+
+  static title = t('Edit');
+
+  static buttonText = t('Edit');
+
+  static policy = onlyAdminCanChangePolicy;
+
+  static allowed = (item) => Promise.resolve(item.source === 'manual');
+
+  init() {
+    this.store = globalMessageBannerStore;
+  }
+
+  get messageType() {
+    return this.item.type;
+  }
+
+  get name() {
+    return t('Edit {type}', {
+      type: getMessageTypeLabel(this.messageType),
+    });
+  }
+
+  get instanceName() {
+    return this.item.title || this.item.id;
+  }
+
+  get defaultValue() {
+    const {
+      title,
+      message,
+      impacted_service,
+      start_at,
+      expires_at,
+      region,
+      enabled,
+    } = this.item;
+    return {
+      title,
+      message,
+      impacted_service,
+      start_at: formatUtcInput(start_at),
+      expires_at: formatUtcInput(expires_at),
+      region,
+      enabled,
+    };
+  }
+
+  getModalSize() {
+    return 'large';
+  }
+
+  get formItems() {
+    const isMaintenance = this.messageType === 'maintenance';
+    return [
+      {
+        name: 'title',
+        label: t('Title'),
+        type: 'input',
+        required: true,
+      },
+      {
+        name: 'impacted_service',
+        label: t('Impacted Service'),
+        type: 'input',
+        required: false,
+        display: isMaintenance,
+      },
+      {
+        name: 'start_at',
+        label: t('Start_Time (UTC)'),
+        type: 'input',
+        placeholder: utcInputPlaceholder,
+        required: isMaintenance,
+        validator: utcTimeValidator,
+        display: isMaintenance,
+      },
+      {
+        name: 'expires_at',
+        label: t('End_Time (UTC)'),
+        type: 'input',
+        placeholder: utcInputPlaceholder,
+        required: true,
+        validator: utcTimeValidator,
+      },
+      {
+        name: 'message',
+        label: t('Message'),
+        type: 'textarea',
+        required: true,
+        rows: 6,
+      },
+    ];
+  }
+
+  onSubmit = (values) =>
+    this.store.edit(
+      { id: this.item.id },
+      getMessageBannerPayload(values, this.messageType)
+    );
+}
+
+export default inject('rootStore')(observer(Edit));

--- a/src/pages/maintenance-notifications/containers/MessageBanner/actions/ToggleEnabled.jsx
+++ b/src/pages/maintenance-notifications/containers/MessageBanner/actions/ToggleEnabled.jsx
@@ -1,0 +1,61 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { ConfirmAction } from 'containers/Action';
+import globalMessageBannerStore from 'stores/skyline/message-banner';
+import { onlyAdminCanChangePolicy } from 'resources/skyline/policy';
+import { getMessageBannerPayload } from 'resources/skyline/message-banner';
+
+export default class ToggleEnabledAction extends ConfirmAction {
+  get id() {
+    return this.item.enabled ? 'disable' : 'enable';
+  }
+
+  get title() {
+    return this.item.enabled
+      ? t('Disable Message Banner')
+      : t('Enable Message Banner');
+  }
+
+  get buttonText() {
+    return this.item.enabled ? t('Disable') : t('Enable');
+  }
+
+  get actionName() {
+    return this.item.enabled
+      ? t('Disable message banner')
+      : t('Enable message banner');
+  }
+
+  policy = onlyAdminCanChangePolicy;
+
+  allowed = (item) => {
+    const isExpired = new Date(item.expires_at) <= new Date();
+    // For rss_feed: only show toggle if currently active (not expired and enabled)
+    if (item.source === 'rss_feed') {
+      return Promise.resolve(!isExpired && item.enabled);
+    }
+    // For manual: only show toggle if not expired
+    return Promise.resolve(!isExpired);
+  };
+
+  getItemName = (data) => data.title || `- (${data.id})`;
+
+  onSubmit = (data) => {
+    const values = {
+      ...data,
+      enabled: !data.enabled,
+    };
+    const body = getMessageBannerPayload(values, data.type);
+    return globalMessageBannerStore.update({ id: data.id }, body);
+  };
+}

--- a/src/pages/maintenance-notifications/containers/MessageBanner/actions/index.jsx
+++ b/src/pages/maintenance-notifications/containers/MessageBanner/actions/index.jsx
@@ -1,0 +1,38 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Create from './CreateMaintenance';
+import CreateNotification from './CreateNotification';
+import Delete from './Delete';
+import Edit from './Edit';
+import ToggleEnabled from './ToggleEnabled';
+
+const maintenanceActionConfigs = {
+  rowActions: {
+    firstAction: Edit,
+    moreActions: [{ action: ToggleEnabled }, { action: Delete }],
+  },
+  batchActions: [],
+  primaryActions: [Create],
+};
+
+const notificationActionConfigs = {
+  rowActions: {
+    firstAction: Edit,
+    moreActions: [{ action: ToggleEnabled }, { action: Delete }],
+  },
+  batchActions: [],
+  primaryActions: [CreateNotification],
+};
+
+export { maintenanceActionConfigs, notificationActionConfigs };
+export default maintenanceActionConfigs;

--- a/src/pages/maintenance-notifications/containers/MessageBanner/index.jsx
+++ b/src/pages/maintenance-notifications/containers/MessageBanner/index.jsx
@@ -1,0 +1,34 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { observer, inject } from 'mobx-react';
+import Base from 'containers/TabList';
+import BannerList from './BannerList';
+
+export class MessageBanner extends Base {
+  get tabs() {
+    return [
+      {
+        title: t('Maintenance'),
+        key: 'maintenance',
+        component: BannerList,
+      },
+      {
+        title: t('Notifications'),
+        key: 'notification',
+        component: BannerList,
+      },
+    ];
+  }
+}
+
+export default inject('rootStore')(observer(MessageBanner));

--- a/src/pages/maintenance-notifications/containers/MessageBanner/index.less
+++ b/src/pages/maintenance-notifications/containers/MessageBanner/index.less
@@ -1,0 +1,4 @@
+.message {
+  max-width: 360px;
+  white-space: pre-line;
+}

--- a/src/pages/maintenance-notifications/routes/index.js
+++ b/src/pages/maintenance-notifications/routes/index.js
@@ -1,0 +1,28 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import BaseLayout from 'layouts/Basic';
+import E404 from 'pages/base/containers/404';
+import MessageBanner from '../containers/MessageBanner';
+
+const PATH = '/maintenance-notifications-admin';
+
+export default [
+  {
+    path: PATH,
+    component: BaseLayout,
+    routes: [
+      { path: `${PATH}/banners`, component: MessageBanner, exact: true },
+      { path: '*', component: E404 },
+    ],
+  },
+];

--- a/src/resources/skyline/message-banner.js
+++ b/src/resources/skyline/message-banner.js
@@ -1,0 +1,108 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import moment from 'moment';
+
+export const MESSAGE_BANNER_TYPE = {
+  maintenance: t('Maintenance'),
+  notification: t('Notification'),
+};
+
+export const MESSAGE_BANNER_SOURCE = {
+  manual: t('Manual'),
+  rss_feed: t('RSS Feed'),
+};
+
+export const messageTypeOptions = Object.keys(MESSAGE_BANNER_TYPE).map(
+  (key) => ({
+    label: MESSAGE_BANNER_TYPE[key],
+    value: key,
+  })
+);
+
+export const sourceOptions = Object.keys(MESSAGE_BANNER_SOURCE).map((key) => ({
+  label: MESSAGE_BANNER_SOURCE[key],
+  value: key,
+}));
+
+export const enabledOptions = [
+  {
+    label: t('Enabled'),
+    value: true,
+  },
+  {
+    label: t('Disabled'),
+    value: false,
+  },
+];
+
+export const utcInputPlaceholder = '2026-05-07T13:00:00Z';
+
+export const getMessageTypeLabel = (type) =>
+  MESSAGE_BANNER_TYPE[type] || type || '-';
+
+export const getMessageSourceLabel = (source) =>
+  MESSAGE_BANNER_SOURCE[source] || source || '-';
+
+export const getEnabledLabel = (enabled) =>
+  enabled ? t('Enabled') : t('Disabled');
+
+export const parseUtcTime = (value) => {
+  if (!value) {
+    return null;
+  }
+  const parsed = moment.utc(
+    value,
+    [moment.ISO_8601, 'YYYY-MM-DD HH:mm:ss'],
+    true
+  );
+  return parsed.isValid() ? parsed : null;
+};
+
+export const normalizeUtcTime = (value) => {
+  const parsed = parseUtcTime(value);
+  return parsed ? parsed.format('YYYY-MM-DDTHH:mm:ss[Z]') : null;
+};
+
+export const formatUtcInput = (value) => normalizeUtcTime(value) || undefined;
+
+export const formatUtcTime = (value) => {
+  const parsed = parseUtcTime(value);
+  return parsed ? parsed.format('YYYY-MM-DD HH:mm:ss [UTC]') : '-';
+};
+
+export const utcTimeValidator = (_rule, value) => {
+  if (!value || parseUtcTime(value)) {
+    return Promise.resolve();
+  }
+  return Promise.reject(new Error(t('Please enter a valid UTC date/time.')));
+};
+
+export const getMessageBannerPayload = (values, type) => {
+  const payload = {
+    type,
+    title: values.title || null,
+    message: values.message,
+    impacted_service: values.impacted_service || null,
+    start_at: normalizeUtcTime(values.start_at),
+    expires_at: normalizeUtcTime(values.expires_at),
+    region: values.region || null,
+    enabled: values.enabled !== false,
+  };
+
+  if (type !== 'maintenance') {
+    payload.impacted_service = null;
+    payload.start_at = null;
+  }
+
+  return payload;
+};

--- a/src/stores/skyline/message-banner.js
+++ b/src/stores/skyline/message-banner.js
@@ -1,0 +1,92 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { action, observable } from 'mobx';
+import { get } from 'lodash';
+import client from 'client';
+import Base from 'stores/base';
+
+export class MessageBannerStore extends Base {
+  @observable
+  activeBanners = [];
+
+  @observable
+  publicBanners = [];
+
+  @observable
+  isActiveLoading = false;
+
+  get client() {
+    return client.skyline.messageBanner;
+  }
+
+  get needGetProject() {
+    return false;
+  }
+
+  async listDidFetch(items, _allProjects, filters) {
+    const { tab } = filters || {};
+    if (!tab || !['maintenance', 'notification'].includes(tab)) {
+      return items.filter((it) => it.type === 'maintenance');
+    }
+    return items.filter((it) => it.type === tab);
+  }
+
+  @action
+  async fetchActive(params) {
+    this.isActiveLoading = true;
+    try {
+      const result = await this.client.active(params);
+      this.activeBanners = get(result, 'message_banners', []);
+      return this.activeBanners;
+    } finally {
+      this.isActiveLoading = false;
+    }
+  }
+
+  @action
+  async fetchPublic(params) {
+    try {
+      const result = await this.client.public(params);
+      this.publicBanners = get(result, 'message_banners', []);
+      return this.publicBanners;
+    } catch (e) {
+      this.publicBanners = [];
+      return [];
+    }
+  }
+
+  @action
+  create(data) {
+    return this.submitting(this.client.create(data));
+  }
+
+  @action
+  edit({ id }, data) {
+    return this.submitting(this.client.update(id, data));
+  }
+
+  @action
+  update({ id }, data) {
+    return this.submitting(this.client.update(id, data));
+  }
+
+  @action
+  batchDelete(rowKeys) {
+    return this.submitting(
+      Promise.all(rowKeys.map((id) => this.client.delete(id)))
+    );
+  }
+}
+
+const globalMessageBannerStore = new MessageBannerStore();
+export default globalMessageBannerStore;


### PR DESCRIPTION
Add Message Banner management for System Maintenance & Notifications

This change introduces message banner support across the Skyline console, giving administrators a dedicated space to communicate planned maintenance and service notifications to users.

`Below new functionality added:-`

- A new System Maintenance section is added to the Administrator view with separate tabs for Maintenance and Notifications, where admins can create, edit, enable/disable, and delete banners.
- Active banners are displayed on the user dashboard (post-login) with auto-slide between multiple messages.
- Active banners are also shown on the login page (pre-login) as a notification card, so users are informed before they sign in.
- RSS feed banners support enable/disable only — edit and delete are restricted to manually created banners.


Pre Login snapshot :-

<img width="1440" height="777" alt="Pre-login-pannel" src="https://github.com/user-attachments/assets/0b3ab80a-5586-44ce-948b-8e3c3786fd7f" />

Post login snapshot:-
<img width="1432" height="762" alt="Post-login-pannel" src="https://github.com/user-attachments/assets/6fe6120b-0cf8-4a6b-9f5a-fd80bd1ac772" />

Administrator window:-
<img width="1425" height="764" alt="Administrator-window" src="https://github.com/user-attachments/assets/27100dc7-bf32-4cb4-a912-54fab107d157" />