### PR TITLE
OSPC-2139:Added the code changes for Zaqar UI implementations

### DIFF
--- a/src/client/client/constants.js
+++ b/src/client/client/constants.js
@@ -38,6 +38,7 @@ export const endpointVersionMap = {
   designate: 'v2',
   masakari: 'v1',
   blazar: 'v1',
+  zaqar: 'v2',
 };
 
 export const endpointsDefault = {
@@ -81,6 +82,7 @@ export const magnumBase = () => getOpenstackEndpoint('magnum');
 export const designateBase = () => getOpenstackEndpoint('designate');
 export const masakariBase = () => getOpenstackEndpoint('masakari');
 export const blazarBase = () => getOpenstackEndpoint('blazar');
+export const zaqarBase = () => getOpenstackEndpoint('zaqar');
 
 export const ironicOriginEndpoint = () => getOriginEndpoint('ironic');
 export const vpnEndpoint = () => getOriginEndpoint('neutron_vpn');
@@ -92,6 +94,7 @@ export const manilaEndpoint = () => getOriginEndpoint('manilav2');
 export const zunEndpoint = () => getOriginEndpoint('zun');
 export const masakariEndpoint = () => getOriginEndpoint('masakari');
 export const blazarEndpoint = () => getOriginEndpoint('blazar');
+export const zaqarEndpoint = () => getOriginEndpoint('zaqar');
 export const firewallEndpoint = () => getOriginEndpoint('neutron_firewall');
 
 export const apiVersionMaps = {

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -31,6 +31,7 @@ import magnum from './magnum';
 import masakari from './masakari';
 import designate from './designate';
 import blazar from './blazar';
+import zaqar from './zaqar';
 
 const client = {
   skyline,
@@ -52,6 +53,7 @@ const client = {
   masakari,
   designate,
   blazar,
+  zaqar,
 };
 
 window.client = client;

--- a/src/client/zaqar/index.js
+++ b/src/client/zaqar/index.js
@@ -1,0 +1,151 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { getZaqarClientId } from 'utils/zaqar';
+import Base from '../client/base';
+import { zaqarBase } from '../client/constants';
+
+const withClientId = (conf = {}) => ({
+  ...conf,
+  headers: {
+    ...(conf.headers || {}),
+    'Client-ID': getZaqarClientId(),
+  },
+});
+
+export class ZaqarClient extends Base {
+  get baseUrl() {
+    return zaqarBase();
+  }
+
+  get request() {
+    const baseRequest = super.request;
+    return {
+      get: (url, params, conf) =>
+        baseRequest.get(url, params, withClientId(conf)),
+      post: (url, data, params, conf) =>
+        baseRequest.post(url, data, params, withClientId(conf)),
+      put: (url, data, params, conf) =>
+        baseRequest.put(url, data, params, withClientId(conf)),
+      delete: (url, data, params, conf) =>
+        baseRequest.delete(url, data, params, withClientId(conf)),
+      patch: (url, data, params, conf) =>
+        baseRequest.patch(url, data, params, withClientId(conf)),
+      head: (url, params, conf) =>
+        baseRequest.head(url, params, withClientId(conf)),
+      copy: (url, params, conf) =>
+        baseRequest.copy(url, params, withClientId(conf)),
+    };
+  }
+
+  get resources() {
+    return [
+      // Queues: GET /v2/queues, PUT /v2/queues/{name}, DELETE /v2/queues/{name}
+      {
+        name: 'queues',
+        key: 'queues',
+        responseKey: 'queue',
+        extendOperations: [
+          {
+            name: 'create',
+            generate: (queueName, data = {}) =>
+              this.request.put(`queues/${queueName}`, data),
+          },
+          {
+            name: 'getStats',
+            generate: (queueName) =>
+              this.request.get(`queues/${queueName}/stats`),
+          },
+          {
+            name: 'postMessages',
+            generate: (queueName, messages) =>
+              this.request.post(`queues/${queueName}/messages`, { messages }),
+          },
+          {
+            name: 'getMetadata',
+            generate: (queueName) => this.request.get(`queues/${queueName}`),
+          },
+          {
+            name: 'setMetadata',
+            generate: (queueName, data) => {
+              // Zaqar PATCH requires JSON Patch format with special content type.
+              // Use "add" op — works for both new and existing keys.
+              const patch = Object.keys(data).map((key) => ({
+                op: 'add',
+                path: `/metadata/${key}`,
+                value: data[key],
+              }));
+              return this.request.patch(`queues/${queueName}`, patch, null, {
+                headers: {
+                  'Content-Type':
+                    'application/openstack-messaging-v2.0-json-patch',
+                },
+              });
+            },
+          },
+          {
+            name: 'deleteQueue',
+            generate: (queueName) => this.request.delete(`queues/${queueName}`),
+          },
+          {
+            name: 'purge',
+            generate: (queueName) =>
+              this.request.delete(`queues/${queueName}/messages`, null, {
+                pop: 20,
+              }),
+          },
+          // createClaim uses raw axios to capture the Location header for the claim ID.
+          // The X-Auth-Token is read from localStorage the same way request.js does it —
+          // no validity check needed here because request interceptors handle token refresh.
+          {
+            name: 'createClaim',
+            generate: (queueName, data) => {
+              const Axios = require('axios').default;
+              const { getLocalStorageItem } = require('utils/local-storage');
+              const keystoneToken = getLocalStorageItem('keystone_token') || '';
+              // limit goes as query param, ttl/grace go in body
+              const { limit, ...body } = data;
+              const url = `${this.baseUrl}/queues/${queueName}/claims${
+                limit ? `?limit=${limit}` : ''
+              }`;
+              return Axios.post(url, body, {
+                headers: {
+                  'Content-Type': 'application/json;charset=UTF-8',
+                  'Client-ID': getZaqarClientId(),
+                  ...(keystoneToken ? { 'X-Auth-Token': keystoneToken } : {}),
+                },
+                validateStatus: (status) => status < 500,
+              });
+            },
+          },
+        ],
+        subResources: [
+          {
+            key: 'messages',
+            responseKey: 'message',
+          },
+          {
+            key: 'claims',
+            responseKey: 'claim',
+          },
+          {
+            key: 'subscriptions',
+            responseKey: 'subscription',
+          },
+        ],
+      },
+    ];
+  }
+}
+
+const zaqarClient = new ZaqarClient();
+export default zaqarClient;

--- a/src/layouts/admin-menu.jsx
+++ b/src/layouts/admin-menu.jsx
@@ -29,6 +29,7 @@ import {
   BookOutlined,
   PlayCircleOutlined,
   CalendarOutlined,
+  MessageOutlined,
 } from '@ant-design/icons';
 
 const renderMenu = (t) => {
@@ -972,6 +973,23 @@ const renderMenu = (t) => {
           name: t('System Maintenance'),
           key: 'maintNotifBannersAdmin',
           level: 1,
+        },
+      ],
+    },
+    {
+      path: '/zaqar-admin',
+      name: t('Messaging'),
+      key: 'zaqarAdmin',
+      icon: <MessageOutlined />,
+      endpoints: 'zaqar',
+      children: [
+        {
+          path: '/zaqar-admin/queues',
+          name: t('Queues'),
+          key: 'zaqarQueuesAdmin',
+          endpoints: 'zaqar',
+          level: 1,
+          children: [],
         },
       ],
     },

--- a/src/layouts/menu.jsx
+++ b/src/layouts/menu.jsx
@@ -27,6 +27,7 @@ import {
   BookOutlined,
   PlayCircleOutlined,
   CalendarOutlined,
+  MessageOutlined,
 } from '@ant-design/icons';
 
 const renderMenu = (t) => {
@@ -802,6 +803,23 @@ const renderMenu = (t) => {
               routePath: '/database/configurations/detail/:id',
             },
           ],
+        },
+      ],
+    },
+    {
+      path: '/zaqar',
+      name: t('Messaging'),
+      key: 'zaqar',
+      icon: <MessageOutlined />,
+      endpoints: 'zaqar',
+      children: [
+        {
+          path: '/zaqar/queues',
+          name: t('Queues'),
+          key: 'zaqarQueues',
+          endpoints: 'zaqar',
+          level: 1,
+          children: [],
         },
       ],
     },

--- a/src/pages/basic/routes/index.js
+++ b/src/pages/basic/routes/index.js
@@ -73,6 +73,9 @@ const InstanceHA = lazy(() =>
 const Reservation = lazy(() =>
   import(/* webpackChunkName: "reservation" */ 'pages/reservation/App')
 );
+const ZaqarApp = lazy(() =>
+  import(/* webpackChunkName: "zaqar" */ 'pages/zaqar/App')
+);
 const PATH = '/';
 
 export default [
@@ -145,6 +148,14 @@ export default [
       {
         path: `/reservation`,
         component: Reservation,
+      },
+      {
+        path: `/zaqar-admin`,
+        component: ZaqarApp,
+      },
+      {
+        path: `/zaqar`,
+        component: ZaqarApp,
       },
       { path: '*', component: E404 },
     ],

--- a/src/pages/zaqar/App.jsx
+++ b/src/pages/zaqar/App.jsx
@@ -1,0 +1,19 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import renderRoutes from 'utils/RouterConfig';
+
+import routes from './routes';
+
+const App = (props) => renderRoutes(routes, props);
+
+export default App;

--- a/src/pages/zaqar/containers/Queue/Detail/Claim/actions/CreateClaim.jsx
+++ b/src/pages/zaqar/containers/Queue/Detail/Claim/actions/CreateClaim.jsx
@@ -1,0 +1,87 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { inject, observer } from 'mobx-react';
+import { ModalAction } from 'containers/Action';
+import globalClaimStore from 'stores/zaqar/claim';
+
+export class CreateClaim extends ModalAction {
+  static id = 'create-claim';
+
+  static title = t('Create Claim');
+
+  static policy = 'messaging:queues:update';
+
+  static allowed = () => Promise.resolve(true);
+
+  init() {
+    this.store = globalClaimStore;
+  }
+
+  get name() {
+    return t('Create Claim');
+  }
+
+  get queueName() {
+    const { match } = this.props;
+    return match && match.params && match.params.id;
+  }
+
+  get formItems() {
+    return [
+      {
+        name: 'ttl',
+        label: t('TTL (seconds)'),
+        type: 'input-number',
+        required: false,
+        min: 60,
+        max: 43200,
+        placeholder: t('Default: 300'),
+        help: t('How long (in seconds) the claim will be valid.'),
+      },
+      {
+        name: 'grace',
+        label: t('Grace (seconds)'),
+        type: 'input-number',
+        required: false,
+        min: 60,
+        max: 43200,
+        placeholder: t('Default: 60'),
+        help: t(
+          'Extra seconds to allow consumers to ack after a claim expires.'
+        ),
+      },
+      {
+        name: 'limit',
+        label: t('Limit'),
+        type: 'input-number',
+        required: false,
+        min: 1,
+        max: 20,
+        placeholder: t('Default: 5'),
+        help: t('Maximum number of messages to claim (1–20).'),
+      },
+    ];
+  }
+
+  onSubmit = (values) => {
+    const { ttl, grace, limit } = values;
+    return globalClaimStore.createClaim(
+      this.queueName,
+      ttl || 300,
+      grace || 60,
+      limit || 5
+    );
+  };
+}
+
+export default inject('rootStore')(observer(CreateClaim));

--- a/src/pages/zaqar/containers/Queue/Detail/Claim/actions/ReleaseClaim.jsx
+++ b/src/pages/zaqar/containers/Queue/Detail/Claim/actions/ReleaseClaim.jsx
@@ -1,0 +1,46 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { ConfirmAction } from 'containers/Action';
+import globalClaimStore from 'stores/zaqar/claim';
+
+export default class ReleaseClaimAction extends ConfirmAction {
+  get id() {
+    return 'release-claim';
+  }
+
+  get title() {
+    return t('Release Claim');
+  }
+
+  get isDanger() {
+    return true;
+  }
+
+  get buttonText() {
+    return t('Release');
+  }
+
+  get actionName() {
+    return t('Release claim');
+  }
+
+  policy = 'messaging:queues:update';
+
+  allowed = () => Promise.resolve(true);
+
+  getItemName = (item) => item.claimId || item.id || '';
+
+  // item here is { claimId, queueName } passed from the Claim tab
+  onSubmit = (item) =>
+    globalClaimStore.releaseClaim(item.queueName, item.claimId);
+}

--- a/src/pages/zaqar/containers/Queue/Detail/Claim/index.jsx
+++ b/src/pages/zaqar/containers/Queue/Detail/Claim/index.jsx
@@ -1,0 +1,321 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React, { Component } from 'react';
+import { observer, inject } from 'mobx-react';
+import {
+  Button,
+  Modal,
+  Form,
+  InputNumber,
+  Table,
+  Tag,
+  Alert,
+  Typography,
+  Space,
+  Divider,
+  Popconfirm,
+} from 'antd';
+import globalClaimStore from 'stores/zaqar/claim';
+
+const { Text } = Typography;
+
+export class ClaimPanel extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      creating: false,
+      releasing: false,
+      modalVisible: false,
+      error: null,
+    };
+    this.formRef = React.createRef();
+  }
+
+  componentDidMount() {
+    // Clear claim data only if we're on a different queue than the last claim
+    const lastQueue = globalClaimStore.lastClaimQueue;
+    if (lastQueue && lastQueue !== this.queueName) {
+      globalClaimStore.clearClaimed();
+    }
+  }
+
+  get queueName() {
+    const { match } = this.props;
+    return match && match.params && match.params.id;
+  }
+
+  get columns() {
+    return [
+      {
+        title: t('Message ID'),
+        dataIndex: 'id',
+        width: 220,
+        render: (value) => (
+          <Text
+            ellipsis={{ tooltip: value }}
+            style={{ fontFamily: 'monospace', maxWidth: 200 }}
+          >
+            {value || '-'}
+          </Text>
+        ),
+      },
+      {
+        title: t('Body'),
+        dataIndex: 'body',
+        width: 280,
+        render: this.renderBody,
+      },
+      {
+        title: t('TTL (s)'),
+        dataIndex: 'ttl',
+        width: 90,
+        render: (v) => (v !== undefined ? v : '-'),
+      },
+      {
+        title: t('Age (s)'),
+        dataIndex: 'age',
+        width: 90,
+        render: (v) => (v !== undefined ? v : '-'),
+      },
+      {
+        title: t('Claim ID'),
+        dataIndex: 'claim_id',
+        width: 220,
+        render: (v) => (
+          <Text
+            ellipsis={{ tooltip: v }}
+            style={{ fontFamily: 'monospace', maxWidth: 200 }}
+          >
+            {v || '-'}
+          </Text>
+        ),
+      },
+    ];
+  }
+
+  openCreateModal = () => {
+    this.setState({ modalVisible: true, error: null });
+  };
+
+  closeCreateModal = () => {
+    this.setState({ modalVisible: false });
+    if (this.formRef.current) {
+      this.formRef.current.resetFields();
+    }
+  };
+
+  handleCreateSubmit = async () => {
+    try {
+      await this.formRef.current.validateFields();
+    } catch {
+      return;
+    }
+    // Read directly from form fields to ensure InputNumber changes are captured
+    const ttl = this.formRef.current.getFieldValue('ttl') || 300;
+    const grace = this.formRef.current.getFieldValue('grace') || 60;
+    const limit = this.formRef.current.getFieldValue('limit') || 1;
+    this.setState({ creating: true, error: null });
+    try {
+      await globalClaimStore.createClaim(this.queueName, ttl, grace, limit);
+      this.setState({
+        creating: false,
+        modalVisible: false,
+      });
+      if (this.formRef.current) {
+        this.formRef.current.resetFields();
+      }
+    } catch (e) {
+      this.setState({
+        creating: false,
+        error: e.message || t('Failed to create claim'),
+      });
+    }
+  };
+
+  handleReleaseClaim = async () => {
+    const claimId = globalClaimStore.lastClaimId;
+    if (!claimId) return;
+    this.setState({ releasing: true, error: null });
+    try {
+      await globalClaimStore.releaseClaim(this.queueName, claimId);
+      globalClaimStore.clearClaimed();
+      this.setState({ releasing: false });
+    } catch (e) {
+      this.setState({
+        releasing: false,
+        error: e.message || t('Failed to release claim'),
+      });
+    }
+  };
+
+  handleClearResults = () => {
+    this.setState({ error: null });
+    globalClaimStore.clearClaimed();
+  };
+
+  renderBody = (body) => {
+    if (body === null || body === undefined) return '-';
+    const display =
+      typeof body === 'object' ? JSON.stringify(body) : String(body);
+    return (
+      <Text ellipsis={{ tooltip: display }} style={{ maxWidth: 250 }}>
+        {display}
+      </Text>
+    );
+  };
+
+  renderCreateModal() {
+    const { modalVisible, creating } = this.state;
+    return (
+      <Modal
+        title={t('Create Claim')}
+        visible={modalVisible}
+        onOk={this.handleCreateSubmit}
+        confirmLoading={creating}
+        onCancel={this.closeCreateModal}
+        okText={t('Create')}
+        cancelText={t('Cancel')}
+        destroyOnClose
+      >
+        <Form
+          ref={this.formRef}
+          layout="vertical"
+          initialValues={{ ttl: 300, grace: 60, limit: 1 }}
+        >
+          <Form.Item
+            name="ttl"
+            label={t('TTL (seconds)')}
+            help={t('How long (in seconds) the claim will be valid.')}
+          >
+            <InputNumber min={60} max={43200} style={{ width: '100%' }} />
+          </Form.Item>
+          <Form.Item
+            name="grace"
+            label={t('Grace (seconds)')}
+            help={t(
+              'Extra seconds to allow consumers to ack after a claim expires.'
+            )}
+          >
+            <InputNumber min={60} max={43200} style={{ width: '100%' }} />
+          </Form.Item>
+          <Form.Item
+            name="limit"
+            label={t('Limit')}
+            help={t('Maximum number of messages to claim (1–20).')}
+          >
+            <InputNumber
+              min={1}
+              max={20}
+              precision={0}
+              style={{ width: '100%' }}
+            />
+          </Form.Item>
+        </Form>
+      </Modal>
+    );
+  }
+
+  render() {
+    const { releasing, error } = this.state;
+    const { claimedMessages } = globalClaimStore;
+    const claimId = globalClaimStore.lastClaimId;
+
+    return (
+      <div style={{ padding: '16px' }}>
+        <Space style={{ marginBottom: 16 }}>
+          <Button type="primary" onClick={this.openCreateModal}>
+            {t('Create Claim')}
+          </Button>
+
+          {claimId && (
+            <Popconfirm
+              title={t(
+                'This will release the claim and make messages available again. Continue?'
+              )}
+              onConfirm={this.handleReleaseClaim}
+              okText={t('Release')}
+              cancelText={t('Cancel')}
+              okButtonProps={{ danger: true }}
+            >
+              <Button danger loading={releasing}>
+                {t('Release Claim')}
+              </Button>
+            </Popconfirm>
+          )}
+
+          {claimedMessages.length > 0 && (
+            <Button onClick={this.handleClearResults}>
+              {t('Clear Results')}
+            </Button>
+          )}
+        </Space>
+
+        {error && (
+          <Alert
+            type="error"
+            message={error}
+            style={{ marginBottom: 16 }}
+            closable
+            onClose={() => this.setState({ error: null })}
+          />
+        )}
+
+        {claimId && (
+          <Alert
+            type="success"
+            style={{ marginBottom: 16 }}
+            message={
+              <span>
+                {t('Claim created successfully. Claim ID:')}{' '}
+                <Text code copyable style={{ fontFamily: 'monospace' }}>
+                  {claimId}
+                </Text>
+              </span>
+            }
+          />
+        )}
+
+        {claimedMessages.length > 0 ? (
+          <>
+            <Divider orientation="left">
+              <Tag color="orange">
+                {`${t('Claimed Messages')} (${claimedMessages.length})`}
+              </Tag>
+            </Divider>
+            <Table
+              rowKey="id"
+              dataSource={claimedMessages}
+              columns={this.columns}
+              pagination={false}
+              size="small"
+              bordered
+            />
+          </>
+        ) : (
+          !claimId && (
+            <Alert
+              type="info"
+              message={t(
+                'Click "Create Claim" to claim messages from this queue. Claimed messages are temporarily locked for exclusive processing.'
+              )}
+            />
+          )
+        )}
+
+        {this.renderCreateModal()}
+      </div>
+    );
+  }
+}
+
+export default inject('rootStore')(observer(ClaimPanel));

--- a/src/pages/zaqar/containers/Queue/Detail/Message/actions/Delete.jsx
+++ b/src/pages/zaqar/containers/Queue/Detail/Message/actions/Delete.jsx
@@ -1,0 +1,54 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { ConfirmAction } from 'containers/Action';
+import globalMessageStore from 'stores/zaqar/message';
+
+export default class Delete extends ConfirmAction {
+  get id() {
+    return 'delete-message';
+  }
+
+  get title() {
+    return t('Delete Message');
+  }
+
+  get actionName() {
+    return t('Delete Message');
+  }
+
+  get buttonText() {
+    return t('Delete');
+  }
+
+  get isDanger() {
+    return true;
+  }
+
+  policy = 'messaging:messages:delete';
+
+  allowedCheckFunc = () => true;
+
+  confirmContext = (data) => {
+    const name = data.id || '';
+    if (this.isBatch) {
+      return t('Are you sure to delete the selected messages?');
+    }
+    return t('Are you sure to delete message {name}?', { name });
+  };
+
+  onSubmit = (item) => {
+    const { match } = this.containerProps || {};
+    const queueName = match && match.params && match.params.id;
+    return globalMessageStore.delete(item, { queueName });
+  };
+}

--- a/src/pages/zaqar/containers/Queue/Detail/Message/actions/PostMessage.jsx
+++ b/src/pages/zaqar/containers/Queue/Detail/Message/actions/PostMessage.jsx
@@ -1,0 +1,74 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { inject, observer } from 'mobx-react';
+import { ModalAction } from 'containers/Action';
+import globalMessageStore from 'stores/zaqar/message';
+
+export class PostMessage extends ModalAction {
+  static id = 'post-message';
+
+  static title = t('Post Message');
+
+  static policy = 'messaging:queues:update';
+
+  static allowed = () => Promise.resolve(true);
+
+  init() {
+    this.store = globalMessageStore;
+  }
+
+  get name() {
+    return t('Post Message');
+  }
+
+  get queueName() {
+    // containerProps is the List component's full props including route match
+    const { match } = this.containerProps || {};
+    if (match && match.params && match.params.id) {
+      return match.params.id;
+    }
+    // fallback: try direct match prop
+    const { match: directMatch } = this.props || {};
+    return directMatch && directMatch.params && directMatch.params.id;
+  }
+
+  get formItems() {
+    return [
+      {
+        name: 'body',
+        label: t('Message Body'),
+        type: 'textarea',
+        required: true,
+        placeholder: t('Enter message body (text or JSON)'),
+        rows: 4,
+      },
+      {
+        name: 'ttl',
+        label: t('TTL (seconds)'),
+        type: 'input-number',
+        required: false,
+        min: 60,
+        max: 1209600,
+        placeholder: t('Default: 3600'),
+        help: t('Time-to-live in seconds (60 – 1,209,600). Default is 3600.'),
+      },
+    ];
+  }
+
+  onSubmit = (values) => {
+    const { body, ttl } = values;
+    return globalMessageStore.create(this.queueName, body, ttl || 3600);
+  };
+}
+
+export default inject('rootStore')(observer(PostMessage));

--- a/src/pages/zaqar/containers/Queue/Detail/Message/actions/index.jsx
+++ b/src/pages/zaqar/containers/Queue/Detail/Message/actions/index.jsx
@@ -1,0 +1,24 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import PostMessage from './PostMessage';
+import Delete from './Delete';
+
+export const actionConfigs = {
+  primaryActions: [PostMessage],
+  rowActions: {
+    firstAction: Delete,
+  },
+  batchActions: [Delete],
+};
+
+export default actionConfigs;

--- a/src/pages/zaqar/containers/Queue/Detail/Message/index.jsx
+++ b/src/pages/zaqar/containers/Queue/Detail/Message/index.jsx
@@ -1,0 +1,146 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react';
+import { observer, inject } from 'mobx-react';
+import { Tag } from 'antd';
+import Base from 'containers/List';
+import globalMessageStore from 'stores/zaqar/message';
+import { actionConfigs } from './actions';
+
+export class MessageList extends Base {
+  init() {
+    this.store = globalMessageStore;
+  }
+
+  get policy() {
+    return 'messaging:queues:get';
+  }
+
+  get name() {
+    return t('Messages');
+  }
+
+  get rowKey() {
+    return 'id';
+  }
+
+  get hideDownload() {
+    return true;
+  }
+
+  get actionConfigs() {
+    return actionConfigs;
+  }
+
+  get queueName() {
+    const { match } = this.props;
+    return match && match.params && match.params.id;
+  }
+
+  // Pass queueName into the fetchList call so the store can use it
+  get initFilter() {
+    return { queueName: this.queueName };
+  }
+
+  renderClaimStatus = (claimId) => {
+    if (!claimId) {
+      return <Tag color="green">{t('Free')}</Tag>;
+    }
+    return (
+      <Tag color="orange" title={claimId}>
+        {t('Claimed')}
+      </Tag>
+    );
+  };
+
+  renderBody = (body) => {
+    if (body === null || body === undefined) {
+      return '-';
+    }
+    let display;
+    if (typeof body === 'object') {
+      display = JSON.stringify(body);
+    } else {
+      display = String(body);
+    }
+    return (
+      <span
+        title={display}
+        style={{
+          maxWidth: 300,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          display: 'inline-block',
+        }}
+      >
+        {display}
+      </span>
+    );
+  };
+
+  getColumns() {
+    return [
+      {
+        title: t('Message ID'),
+        dataIndex: 'id',
+        width: 220,
+        render: (value) => (
+          <span
+            title={value}
+            style={{
+              fontFamily: 'monospace',
+              maxWidth: 200,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              display: 'inline-block',
+            }}
+          >
+            {value || '-'}
+          </span>
+        ),
+      },
+      {
+        title: t('Body'),
+        dataIndex: 'body',
+        width: 300,
+        render: this.renderBody,
+      },
+      {
+        title: t('TTL (s)'),
+        dataIndex: 'ttl',
+        width: 100,
+        render: (value) => (value !== undefined ? value : '-'),
+      },
+      {
+        title: t('Age (s)'),
+        dataIndex: 'age',
+        width: 100,
+        render: (value) => (value !== undefined ? value : '-'),
+      },
+      {
+        title: t('Status'),
+        dataIndex: 'claim_id',
+        width: 120,
+        render: this.renderClaimStatus,
+      },
+    ];
+  }
+
+  get searchFilters() {
+    return [];
+  }
+}
+
+export default inject('rootStore')(observer(MessageList));

--- a/src/pages/zaqar/containers/Queue/Detail/Subscription/actions/CreateSubscription.jsx
+++ b/src/pages/zaqar/containers/Queue/Detail/Subscription/actions/CreateSubscription.jsx
@@ -1,0 +1,79 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { inject, observer } from 'mobx-react';
+import { ModalAction } from 'containers/Action';
+import globalSubscriptionStore from 'stores/zaqar/subscription';
+
+export class CreateSubscription extends ModalAction {
+  static id = 'create-subscription';
+
+  static title = t('Create Subscription');
+
+  static policy = 'messaging:queues:update';
+
+  static allowed = () => Promise.resolve(true);
+
+  init() {
+    this.store = globalSubscriptionStore;
+  }
+
+  get name() {
+    return t('Create Subscription');
+  }
+
+  get queueName() {
+    // containerProps is the List component's full props including route match
+    const { match } = this.containerProps || {};
+    if (match && match.params && match.params.id) {
+      return match.params.id;
+    }
+    // fallback: try direct match prop (when action is opened from within the page)
+    const { match: directMatch } = this.props || {};
+    return directMatch && directMatch.params && directMatch.params.id;
+  }
+
+  get formItems() {
+    return [
+      {
+        name: 'subscriber',
+        label: t('Subscriber URL'),
+        type: 'input',
+        required: true,
+        placeholder: t('e.g. http://example.com/webhook'),
+        help: t(
+          'The URL endpoint that will receive event notifications for this queue.'
+        ),
+      },
+      {
+        name: 'ttl',
+        label: t('TTL (seconds)'),
+        type: 'input-number',
+        required: false,
+        min: 60,
+        placeholder: t('Default: 3600'),
+        help: t('Time-to-live for the subscription in seconds.'),
+      },
+    ];
+  }
+
+  onSubmit = (values) => {
+    const { subscriber, ttl } = values;
+    return globalSubscriptionStore.create(
+      this.queueName,
+      subscriber,
+      ttl || 3600
+    );
+  };
+}
+
+export default inject('rootStore')(observer(CreateSubscription));

--- a/src/pages/zaqar/containers/Queue/Detail/Subscription/actions/DeleteSubscription.jsx
+++ b/src/pages/zaqar/containers/Queue/Detail/Subscription/actions/DeleteSubscription.jsx
@@ -1,0 +1,55 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { ConfirmAction } from 'containers/Action';
+import globalSubscriptionStore from 'stores/zaqar/subscription';
+
+export default class DeleteSubscriptionAction extends ConfirmAction {
+  get id() {
+    return 'delete-subscription';
+  }
+
+  get title() {
+    return t('Delete Subscription');
+  }
+
+  get isDanger() {
+    return true;
+  }
+
+  get buttonText() {
+    return t('Delete');
+  }
+
+  get actionName() {
+    return t('Delete subscription');
+  }
+
+  policy = 'messaging:queues:update';
+
+  allowed = () => Promise.resolve(true);
+
+  getItemName = (item) => {
+    if (!item) return '-';
+    // batch delete passes subscription IDs as strings; row delete passes objects
+    return typeof item === 'string' ? item : item.subscriber || item.id || '-';
+  };
+
+  get queueName() {
+    // containerProps has the parent List component's props (including match.params)
+    const { match } = this.containerProps || {};
+    return match && match.params && match.params.id;
+  }
+
+  onSubmit = (item) =>
+    globalSubscriptionStore.delete({ id: item.id, queueName: this.queueName });
+}

--- a/src/pages/zaqar/containers/Queue/Detail/Subscription/actions/UpdateSubscription.jsx
+++ b/src/pages/zaqar/containers/Queue/Detail/Subscription/actions/UpdateSubscription.jsx
@@ -1,0 +1,72 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { inject, observer } from 'mobx-react';
+import { ModalAction } from 'containers/Action';
+import globalSubscriptionStore from 'stores/zaqar/subscription';
+
+export class UpdateSubscription extends ModalAction {
+  static id = 'update-subscription';
+
+  static title = t('Update Subscription');
+
+  static buttonText = t('Update');
+
+  static policy = 'messaging:subscriptions:update';
+
+  static allowed = () => Promise.resolve(true);
+
+  init() {
+    this.store = globalSubscriptionStore;
+  }
+
+  get queueName() {
+    const { match } = this.containerProps || {};
+    return match && match.params && match.params.id;
+  }
+
+  get name() {
+    return t('Update Subscription');
+  }
+
+  get instanceName() {
+    return this.item.id;
+  }
+
+  get defaultValue() {
+    return {
+      ttl: this.item.ttl || 3600,
+    };
+  }
+
+  get formItems() {
+    return [
+      {
+        name: 'ttl',
+        label: t('TTL (seconds)'),
+        type: 'input-number',
+        required: true,
+        min: 60,
+        max: 1209600,
+        help: t('Time-to-live in seconds for the subscription.'),
+      },
+    ];
+  }
+
+  onSubmit = (values) =>
+    globalSubscriptionStore.update(
+      { id: this.item.id, queueName: this.queueName },
+      { ttl: values.ttl }
+    );
+}
+
+export default inject('rootStore')(observer(UpdateSubscription));

--- a/src/pages/zaqar/containers/Queue/Detail/Subscription/actions/index.jsx
+++ b/src/pages/zaqar/containers/Queue/Detail/Subscription/actions/index.jsx
@@ -1,0 +1,26 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import CreateSubscription from './CreateSubscription';
+import DeleteSubscription from './DeleteSubscription';
+import UpdateSubscription from './UpdateSubscription';
+
+export const actionConfigs = {
+  primaryActions: [CreateSubscription],
+  rowActions: {
+    firstAction: UpdateSubscription,
+    moreActions: [{ action: DeleteSubscription }],
+  },
+  batchActions: [],
+};
+
+export default actionConfigs;

--- a/src/pages/zaqar/containers/Queue/Detail/Subscription/index.jsx
+++ b/src/pages/zaqar/containers/Queue/Detail/Subscription/index.jsx
@@ -1,0 +1,91 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { observer, inject } from 'mobx-react';
+import Base from 'containers/List';
+import globalSubscriptionStore from 'stores/zaqar/subscription';
+import { actionConfigs } from './actions';
+
+export class SubscriptionList extends Base {
+  init() {
+    this.store = globalSubscriptionStore;
+  }
+
+  get policy() {
+    return 'messaging:queues:get';
+  }
+
+  get name() {
+    return t('Subscriptions');
+  }
+
+  get rowKey() {
+    return 'id';
+  }
+
+  get hideDownload() {
+    return true;
+  }
+
+  get actionConfigs() {
+    return actionConfigs;
+  }
+
+  get queueName() {
+    const { match } = this.props;
+    return match && match.params && match.params.id;
+  }
+
+  get initFilter() {
+    return { queueName: this.queueName };
+  }
+
+  getColumns() {
+    return [
+      {
+        title: t('Subscription ID'),
+        dataIndex: 'id',
+        width: 280,
+        render: (value) => value || '-',
+      },
+      {
+        title: t('Subscriber URL'),
+        dataIndex: 'subscriber',
+        width: 300,
+        render: (value) => value || '-',
+      },
+      {
+        title: t('TTL (s)'),
+        dataIndex: 'ttl',
+        width: 100,
+        render: (value) => (value !== undefined ? value : '-'),
+      },
+      {
+        title: t('Age (s)'),
+        dataIndex: 'age',
+        width: 100,
+        render: (value) => (value !== undefined ? value : '-'),
+      },
+    ];
+  }
+
+  get searchFilters() {
+    return [
+      {
+        label: t('Subscriber URL'),
+        name: 'subscriber',
+      },
+    ];
+  }
+}
+
+export default inject('rootStore')(observer(SubscriptionList));

--- a/src/pages/zaqar/containers/Queue/Detail/index.jsx
+++ b/src/pages/zaqar/containers/Queue/Detail/index.jsx
@@ -1,0 +1,50 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { observer, inject } from 'mobx-react';
+import Base from 'containers/TabList';
+import MessageTab from './Message';
+import ClaimTab from './Claim';
+import SubscriptionTab from './Subscription';
+
+export class QueueDetail extends Base {
+  get queueName() {
+    const { match } = this.props;
+    return match && match.params && match.params.id;
+  }
+
+  get name() {
+    return this.queueName || t('Queue Detail');
+  }
+
+  get tabs() {
+    return [
+      {
+        title: t('Messages'),
+        key: 'messages',
+        component: MessageTab,
+      },
+      {
+        title: t('Claims'),
+        key: 'claims',
+        component: ClaimTab,
+      },
+      {
+        title: t('Subscriptions'),
+        key: 'subscriptions',
+        component: SubscriptionTab,
+      },
+    ];
+  }
+}
+
+export default inject('rootStore')(observer(QueueDetail));

--- a/src/pages/zaqar/containers/Queue/actions/Create.jsx
+++ b/src/pages/zaqar/containers/Queue/actions/Create.jsx
@@ -1,0 +1,52 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { inject, observer } from 'mobx-react';
+import { ModalAction } from 'containers/Action';
+import globalQueueStore from 'stores/zaqar/queue';
+
+export class Create extends ModalAction {
+  static id = 'create-queue';
+
+  static title = t('Create Queue');
+
+  static policy = 'messaging:queues:create';
+
+  static allowed = () => Promise.resolve(true);
+
+  init() {
+    this.store = globalQueueStore;
+  }
+
+  get name() {
+    return t('Create Queue');
+  }
+
+  get formItems() {
+    return [
+      {
+        name: 'name',
+        label: t('Queue Name'),
+        type: 'input',
+        required: true,
+        placeholder: t('Enter queue name'),
+        help: t(
+          'Queue names may only contain letters, digits, underscores and hyphens.'
+        ),
+      },
+    ];
+  }
+
+  onSubmit = (values) => globalQueueStore.create({ name: values.name });
+}
+
+export default inject('rootStore')(observer(Create));

--- a/src/pages/zaqar/containers/Queue/actions/Delete.jsx
+++ b/src/pages/zaqar/containers/Queue/actions/Delete.jsx
@@ -1,0 +1,48 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { ConfirmAction } from 'containers/Action';
+import globalQueueStore from 'stores/zaqar/queue';
+
+export default class DeleteAction extends ConfirmAction {
+  get id() {
+    return 'delete-queue';
+  }
+
+  get title() {
+    return t('Delete Queue');
+  }
+
+  get isDanger() {
+    return true;
+  }
+
+  get buttonText() {
+    return t('Delete');
+  }
+
+  get actionName() {
+    return t('Delete queue');
+  }
+
+  policy = 'messaging:queues:delete';
+
+  allowed = () => Promise.resolve(true);
+
+  getItemName = (item) => {
+    if (!item) return '-';
+    // batch delete passes name strings; row delete passes objects
+    return typeof item === 'string' ? item : item.name || '-';
+  };
+
+  onSubmit = (item) => globalQueueStore.delete({ name: item.name });
+}

--- a/src/pages/zaqar/containers/Queue/actions/EditMetadata.jsx
+++ b/src/pages/zaqar/containers/Queue/actions/EditMetadata.jsx
@@ -1,0 +1,97 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { inject, observer } from 'mobx-react';
+import { ModalAction } from 'containers/Action';
+import globalQueueStore from 'stores/zaqar/queue';
+
+export class EditMetadata extends ModalAction {
+  static id = 'edit-queue-metadata';
+
+  static title = t('Edit Metadata');
+
+  static policy = 'messaging:queues:update';
+
+  static allowed = () => Promise.resolve(true);
+
+  init() {
+    this.store = globalQueueStore;
+    this.metadata = {};
+    this.fetchMetadata();
+  }
+
+  async fetchMetadata() {
+    try {
+      const result = (await globalQueueStore.getMetadata(this.item.name)) || {};
+      const metadata =
+        result.metadata ||
+        (result.queue && result.queue.metadata) ||
+        (!result.name && !result.href ? result : {});
+      this.metadata = metadata || {};
+      this.updateDefaultValue();
+    } catch {
+      this.updateDefaultValue();
+    }
+  }
+
+  get name() {
+    return t('Edit Queue Metadata');
+  }
+
+  get defaultValue() {
+    return {
+      metadata: JSON.stringify(
+        this.metadata || this.item.metadata || {},
+        null,
+        2
+      ),
+    };
+  }
+
+  get formItems() {
+    return [
+      {
+        name: 'metadata',
+        label: t('Metadata (JSON)'),
+        type: 'textarea',
+        rows: 10,
+        required: false,
+        placeholder: '{}',
+        help: t('Enter valid JSON for the queue metadata.'),
+        validator: (_rule, value) => {
+          if (!value || value.trim() === '') {
+            return Promise.resolve();
+          }
+          try {
+            JSON.parse(value);
+            return Promise.resolve();
+          } catch (e) {
+            return Promise.reject(new Error(t('Please enter valid JSON.')));
+          }
+        },
+      },
+    ];
+  }
+
+  onSubmit = (values) => {
+    const raw = values.metadata ? values.metadata.trim() : '{}';
+    let parsed;
+    try {
+      parsed = JSON.parse(raw || '{}');
+    } catch {
+      parsed = {};
+    }
+    return globalQueueStore.setMetadata(this.item.name, parsed);
+  };
+}
+
+export default inject('rootStore')(observer(EditMetadata));

--- a/src/pages/zaqar/containers/Queue/actions/Purge.jsx
+++ b/src/pages/zaqar/containers/Queue/actions/Purge.jsx
@@ -1,0 +1,52 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { ConfirmAction } from 'containers/Action';
+import globalQueueStore from 'stores/zaqar/queue';
+
+export default class PurgeAction extends ConfirmAction {
+  get id() {
+    return 'purge-queue';
+  }
+
+  get title() {
+    return t('Purge Queue');
+  }
+
+  get isDanger() {
+    return true;
+  }
+
+  get buttonText() {
+    return t('Purge');
+  }
+
+  get actionName() {
+    return t('Purge all messages from queue');
+  }
+
+  confirmContext = () =>
+    t(
+      'This will permanently delete ALL messages in the queue. This action cannot be undone.'
+    );
+
+  policy = 'messaging:queues:update';
+
+  allowed = () => Promise.resolve(true);
+
+  getItemName = (item) => {
+    if (!item) return '-';
+    return typeof item === 'string' ? item : item.name || '-';
+  };
+
+  onSubmit = (item) => globalQueueStore.purge(item.name);
+}

--- a/src/pages/zaqar/containers/Queue/actions/index.jsx
+++ b/src/pages/zaqar/containers/Queue/actions/index.jsx
@@ -1,0 +1,27 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Create from './Create';
+import Delete from './Delete';
+import Purge from './Purge';
+import EditMetadata from './EditMetadata';
+
+export const actionConfigs = {
+  primaryActions: [Create],
+  rowActions: {
+    firstAction: Delete,
+    moreActions: [{ action: Purge }, { action: EditMetadata }],
+  },
+  batchActions: [],
+};
+
+export default actionConfigs;

--- a/src/pages/zaqar/containers/Queue/index.jsx
+++ b/src/pages/zaqar/containers/Queue/index.jsx
@@ -1,0 +1,117 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react';
+import { observer, inject } from 'mobx-react';
+import { Link } from 'react-router-dom';
+import Base from 'containers/List';
+import globalQueueStore from 'stores/zaqar/queue';
+import { zaqarEndpoint } from 'client/client/constants';
+import { actionConfigs } from './actions';
+
+export class Queue extends Base {
+  init() {
+    this.store = globalQueueStore;
+  }
+
+  get policy() {
+    return 'messaging:queues:get';
+  }
+
+  get endpoint() {
+    return zaqarEndpoint();
+  }
+
+  get checkEndpoint() {
+    return true;
+  }
+
+  get name() {
+    return t('Queues');
+  }
+
+  get rowKey() {
+    return 'name';
+  }
+
+  get hideDownload() {
+    return true;
+  }
+
+  get actionConfigs() {
+    return actionConfigs;
+  }
+
+  getColumns() {
+    const basePath = this.isAdminPage ? '/zaqar-admin' : '/zaqar';
+    return [
+      {
+        title: t('Queue Name'),
+        dataIndex: 'name',
+        width: 240,
+        render: (value) =>
+          value ? (
+            <Link to={`${basePath}/queues/${encodeURIComponent(value)}`}>
+              {value}
+            </Link>
+          ) : (
+            '-'
+          ),
+      },
+      {
+        title: t('Messages Total'),
+        dataIndex: 'messages_total',
+        width: 150,
+        render: (_, record) => {
+          const total =
+            record.stats &&
+            record.stats.messages &&
+            record.stats.messages.total;
+          return total !== undefined ? total : '-';
+        },
+      },
+      {
+        title: t('Messages Free'),
+        dataIndex: 'messages_free',
+        width: 150,
+        render: (_, record) => {
+          const free =
+            record.stats && record.stats.messages && record.stats.messages.free;
+          return free !== undefined ? free : '-';
+        },
+      },
+      {
+        title: t('Messages Claimed'),
+        dataIndex: 'messages_claimed',
+        width: 150,
+        render: (_, record) => {
+          const claimed =
+            record.stats &&
+            record.stats.messages &&
+            record.stats.messages.claimed;
+          return claimed !== undefined ? claimed : '-';
+        },
+      },
+    ];
+  }
+
+  get searchFilters() {
+    return [
+      {
+        label: t('Queue Name'),
+        name: 'name',
+      },
+    ];
+  }
+}
+
+export default inject('rootStore')(observer(Queue));

--- a/src/pages/zaqar/routes/index.js
+++ b/src/pages/zaqar/routes/index.js
@@ -1,0 +1,37 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import BaseLayout from 'layouts/Basic';
+import E404 from 'pages/base/containers/404';
+import Queue from '../containers/Queue';
+import QueueDetail from '../containers/Queue/Detail';
+
+export default [
+  {
+    path: '/zaqar-admin',
+    component: BaseLayout,
+    routes: [
+      { path: '/zaqar-admin/queues', component: Queue, exact: true },
+      { path: '/zaqar-admin/queues/:id', component: QueueDetail, exact: true },
+      { path: '*', component: E404 },
+    ],
+  },
+  {
+    path: '/zaqar',
+    component: BaseLayout,
+    routes: [
+      { path: '/zaqar/queues', component: Queue, exact: true },
+      { path: '/zaqar/queues/:id', component: QueueDetail, exact: true },
+      { path: '*', component: E404 },
+    ],
+  },
+];

--- a/src/resources/skyline/policy.js
+++ b/src/resources/skyline/policy.js
@@ -91,6 +91,7 @@ export const policyMap = {
     'backup:show',
   ],
   blazar: ['osreservations:'],
+  zaqar: ['messaging:'],
 };
 
 export const convertPolicyMap = (map) => {

--- a/src/resources/zaqar/queue.js
+++ b/src/resources/zaqar/queue.js
@@ -1,0 +1,27 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ---------------------------------------------------------------------------
+// Zaqar Queue resource constants, label helpers and search filter options.
+// ---------------------------------------------------------------------------
+
+export const QUEUE_STATUS = {
+  active: t('Active'),
+};
+
+export const getQueueStatusLabel = (status) =>
+  QUEUE_STATUS[status] || status || '-';
+
+export const queueStatusOptions = Object.keys(QUEUE_STATUS).map((key) => ({
+  label: QUEUE_STATUS[key],
+  value: key,
+}));

--- a/src/stores/zaqar/claim.js
+++ b/src/stores/zaqar/claim.js
@@ -1,0 +1,103 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { action, observable } from 'mobx';
+import client from 'client';
+import Base from 'stores/base';
+
+export class ClaimStore extends Base {
+  @observable
+  claimedMessages = [];
+
+  @observable
+  lastClaimId = null;
+
+  @observable
+  lastClaimQueue = null;
+
+  get client() {
+    return client.zaqar.queues.claims;
+  }
+
+  get needGetProject() {
+    return false;
+  }
+
+  get listResponseKey() {
+    return null;
+  }
+
+  get paramsFunc() {
+    return () => ({});
+  }
+
+  // Create a claim — returns the array of claimed messages
+  // POST /v2/queues/{name}/claims
+  @action
+  createClaim = async (queueName, ttl = 300, grace = 60, limit = 1) => {
+    // Use createClaim which returns the full axios response so we can read Location header
+    const response = await this.submitting(
+      client.zaqar.queues.createClaim(queueName, { ttl, grace, limit })
+    );
+
+    // Extract claimed messages from response body
+    const responseData = response && response.data;
+    let messages = [];
+    if (Array.isArray(responseData)) {
+      messages = responseData;
+    } else if (responseData && Array.isArray(responseData.messages)) {
+      messages = responseData.messages;
+    }
+
+    // Extract claim ID from Location header: /v2/queues/{name}/claims/{id}
+    const locationHeader =
+      response &&
+      response.headers &&
+      (response.headers.location || response.headers.Location);
+    let claimId = null;
+    if (locationHeader) {
+      const parts = locationHeader.split('/claims/');
+      claimId = parts.length > 1 ? parts[1].split('/')[0] : null;
+    }
+    // Fallback: try from message claim_id field
+    if (!claimId && messages.length > 0) {
+      claimId =
+        messages[0].claim_id ||
+        (messages[0].href
+          ? messages[0].href.split('/claims/')[1]?.split('/')[0]
+          : null);
+    }
+
+    this.claimedMessages = messages.map((item) => ({
+      ...item,
+      id: item.href ? item.href.split('/messages/')[1] : item.id,
+    }));
+    this.lastClaimId = claimId;
+    this.lastClaimQueue = queueName;
+    return { messages: this.claimedMessages, claimId };
+  };
+
+  // DELETE /v2/queues/{name}/claims/{claim_id}
+  @action
+  releaseClaim = (queueName, claimId) =>
+    this.submitting(this.client.delete(queueName, claimId));
+
+  @action
+  clearClaimed() {
+    this.claimedMessages = [];
+    this.lastClaimId = null;
+    this.lastClaimQueue = null;
+  }
+}
+
+const globalClaimStore = new ClaimStore();
+export default globalClaimStore;

--- a/src/stores/zaqar/message.js
+++ b/src/stores/zaqar/message.js
@@ -1,0 +1,74 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { action } from 'mobx';
+import client from 'client';
+import Base from 'stores/base';
+
+export class MessageStore extends Base {
+  get client() {
+    return client.zaqar.queues.messages;
+  }
+
+  get needGetProject() {
+    return false;
+  }
+
+  get listResponseKey() {
+    return 'messages';
+  }
+
+  // Extract id from href: /v2/queues/{name}/messages/{id}
+  get mapper() {
+    return (item) => ({
+      ...item,
+      id: item.href ? item.href.split('/').pop() : item.id,
+    });
+  }
+
+  get paramsFunc() {
+    return () => ({});
+  }
+
+  // Override listFetchByClient to pass echo=true query param
+  listFetchByClient(params, originParams) {
+    // queueName may come from initFilter or from route params merged in getData
+    const queueName =
+      (originParams && originParams.queueName) ||
+      (originParams && originParams.id);
+    return this.client.list(queueName, { ...params, echo: true });
+  }
+
+  getFatherResourceId = (params) =>
+    (params && params.queueName) || (params && params.id);
+
+  @action
+  create = (queueName, body, ttl) => {
+    // Use extendOperation to post messages as array with Client-ID header
+    const messages = [{ body, ttl: ttl || 3600 }];
+    return this.submitting(
+      client.zaqar.queues.postMessages(queueName, messages)
+    );
+  };
+
+  @action
+  delete = (item, params = {}) => {
+    const queueName = params.queueName || item.queueName;
+    const messageId = item.id;
+    return this.submitting(
+      client.zaqar.queues.messages.delete(queueName, messageId)
+    );
+  };
+}
+
+const globalMessageStore = new MessageStore();
+export default globalMessageStore;

--- a/src/stores/zaqar/queue.js
+++ b/src/stores/zaqar/queue.js
@@ -1,0 +1,103 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { action } from 'mobx';
+import client from 'client';
+import Base from 'stores/base';
+
+export class QueueStore extends Base {
+  get client() {
+    return client.zaqar.queues;
+  }
+
+  get needGetProject() {
+    return false;
+  }
+
+  // Tell the base store that the list lives under the "queues" key in the response.
+  get listResponseKey() {
+    return 'queues';
+  }
+
+  // Add "id" field (same as name) so the base List component can key rows.
+  get mapper() {
+    return (item) => ({
+      ...item,
+      id: item.name,
+    });
+  }
+
+  get paramsFunc() {
+    return () => ({});
+  }
+
+  @action
+  create = (data) =>
+    this.submitting(this.client.create(data.name, data.metadata || {}));
+
+  @action
+  delete = ({ name }) => this.submitting(this.client.deleteQueue(name));
+
+  @action
+  getStats(name) {
+    return this.client.getStats(name);
+  }
+
+  @action
+  getMetadata(name) {
+    return this.client.getMetadata(name);
+  }
+
+  async listDidFetch(items) {
+    if (!items.length) {
+      return items;
+    }
+
+    const statsList = await Promise.all(
+      items.map(async (item) => {
+        try {
+          const stats = await this.getStats(item.name);
+          return {
+            ...item,
+            stats,
+          };
+        } catch (e) {
+          return item;
+        }
+      })
+    );
+
+    return statsList;
+  }
+
+  @action
+  setMetadata(name, data) {
+    return this.submitting(this.client.setMetadata(name, data));
+  }
+
+  @action
+  purge = async (name) => {
+    // Zaqar limits pop to max 20 per call — loop until queue is empty.
+    // eslint-disable-next-line no-await-in-loop
+    let deleted = 0;
+    do {
+      // eslint-disable-next-line no-await-in-loop
+      const result = await this.client.purge(name);
+      // result may be an array of deleted messages or null
+      const count = Array.isArray(result) ? result.length : 0;
+      deleted = count;
+    } while (deleted > 0);
+  };
+}
+
+const globalQueueStore = new QueueStore();
+export default globalQueueStore;

--- a/src/stores/zaqar/subscription.js
+++ b/src/stores/zaqar/subscription.js
@@ -1,0 +1,58 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { action } from 'mobx';
+import client from 'client';
+import Base from 'stores/base';
+
+export class SubscriptionStore extends Base {
+  get client() {
+    return client.zaqar.queues.subscriptions;
+  }
+
+  get needGetProject() {
+    return false;
+  }
+
+  get listResponseKey() {
+    return 'subscriptions';
+  }
+
+  get paramsFunc() {
+    return () => ({});
+  }
+
+  listFetchByClient(params, originParams) {
+    const queueName =
+      (originParams && originParams.queueName) ||
+      (originParams && originParams.id);
+    return this.client.list(queueName, params);
+  }
+
+  getFatherResourceId = (params) =>
+    (params && params.queueName) || (params && params.id);
+
+  @action
+  create = (queueName, subscriber, ttl = 3600) =>
+    this.submitting(this.client.create(queueName, { subscriber, ttl }));
+
+  @action
+  update = ({ id, queueName }, data) =>
+    this.submitting(this.client.patch(queueName, id, data));
+
+  @action
+  delete = ({ id, queueName }) =>
+    this.submitting(this.client.delete(queueName, id));
+}
+
+const globalSubscriptionStore = new SubscriptionStore();
+export default globalSubscriptionStore;

--- a/src/utils/zaqar.js
+++ b/src/utils/zaqar.js
@@ -1,0 +1,36 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { v4 as uuidv4 } from 'uuid';
+
+const ZAQAR_CLIENT_UUID_KEY = 'zaqar_client_uuid';
+
+/**
+ * Get or generate a Zaqar Client-ID (RFC 4122 UUID).
+ *
+ * Zaqar API requires a unique Client-ID header on every request to:
+ *   - Prevent message echo (client won't receive its own posted messages)
+ *   - Track claim ownership per client
+ *
+ * We use sessionStorage so that:
+ *   - Each browser session gets its own UUID (isolates concurrent users)
+ *   - The UUID survives page refreshes within the same tab
+ *   - It auto-clears when the tab/browser closes (no stale state)
+ */
+export const getZaqarClientId = () => {
+  let clientId = sessionStorage.getItem(ZAQAR_CLIENT_UUID_KEY);
+  if (!clientId) {
+    clientId = uuidv4();
+    sessionStorage.setItem(ZAQAR_CLIENT_UUID_KEY, clientId);
+  }
+  return clientId;
+};


### PR DESCRIPTION
Added the functionality for  Zaqar Messaging UI support to Skyline Console, providing queue, message, claim, and subscription management.

Attached the Image below:-
Queues:-
<img width="1440" height="777" alt="Zaqar-UI-Messaging-Bar-Quesues-1" src="https://github.com/user-attachments/assets/8039ae91-d432-45e8-b19d-6842ea0f2c6e" />


Message Display -
<img width="1438" height="768" alt="Message-Display-For-Queues" src="https://github.com/user-attachments/assets/b81a0d3f-e361-45cb-bfd4-dff447d424cb" />


Claim:-
<img width="1431" height="766" alt="Zaqar_claim_Created-2" src="https://github.com/user-attachments/assets/804b9495-c214-49d1-99bc-e4c7c856d8f3" />

Subscription:-
<img width="1434" height="774" alt="Zaqar_subscription_Created" src="https://github.com/user-attachments/assets/05228532-d3a0-4bd0-9cd6-4e47a0d30bc9" />
